### PR TITLE
STU-450: Set amplitude id on the first survey display if it doesn't exist

### DIFF
--- a/Sources/KovaleeSurvey/KovaleeSurveyManagerImpl.swift
+++ b/Sources/KovaleeSurvey/KovaleeSurveyManagerImpl.swift
@@ -62,6 +62,13 @@ class KovaleeSurveyManagerImpl: SurveyManager, Manager {
 }
 
 extension KovaleeSurveyManagerImpl: SurvicateDelegate {
+
+    func surveyDisplayed(event: SurveyDisplayedEvent) {
+        if Kovalee.getAmplitudeUserId() == nil {
+            Kovalee.setAmplitudeUserId(userId: UUID().uuidString)
+        }
+    }
+
     func surveyClosed(surveyId: String) {
         delegate?.surveyClosed(surveyId: surveyId)
     }


### PR DESCRIPTION
# [STU-450](https://linear.app/kovalee-studio/issue/STU-450): Set amplitude id on the first survey display if it doesn't exist

## Description
- Checks for `amplitudeId` when survey is displayed
- Assing a new value in case `amplitudeId` is `nil`

This change will prevent survey events having no associated `amplitudeId`, making it impossible to relate survey events to specific users.

The `surveyDisplayed(event:)` will eep private inside **KovaleeSDK**.