### PR TITLE
Feat: Import all the Import all the podspec files from the different packages files from the different packages

### DIFF
--- a/KovaleeAttribution.podspec
+++ b/KovaleeAttribution.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
                    DESC
 
   spec.license        = { :type => 'MIT', :file => 'MIT-LICENSE' }
-  spec.homepage     = "https://github.com/cotyapps/KovaleeAttribution-iOS"
+  spec.homepage     = "https://github.com/cotyapps/Kovalee-iOS-SDK.git"
   spec.author       = { "fto-k" => "fto@kovalee.app" }
 
   spec.source       = { :git => "https://github.com/cotyapps/Kovalee-iOS-SDK.git", :tag => "#{spec.version}" }

--- a/KovaleeAttribution.podspec
+++ b/KovaleeAttribution.podspec
@@ -1,0 +1,31 @@
+#
+#  Be sure to run `pod spec lint KovaleeAttribution.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see https://guides.cocoapods.org/syntax/podspec.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |spec|
+  spec.name         = "KovaleeAttribution"
+  spec.version      = "2.0.0"
+  spec.summary      = "KovaleeAttribution automates users attribution."
+  spec.description  = <<-DESC
+  Measuring marketing effectiveness and understanding where your users come from can be tricky. KovaleeAttribution automates this process, making the identification a breeze.
+  It's part of a broader project KovaleeSDK
+                   DESC
+
+  spec.license        = { :type => 'MIT', :file => 'MIT-LICENSE' }
+  spec.homepage     = "https://github.com/cotyapps/KovaleeAttribution-iOS"
+  spec.author       = { "fto-k" => "fto@kovalee.app" }
+
+  spec.source       = { :git => "https://github.com/cotyapps/Kovalee-iOS-SDK.git", :tag => "#{spec.version}" }
+
+  spec.ios.deployment_target = '14.3'
+  spec.swift_version    = '5.7'
+  spec.source_files  = "Sources/KovaleeAttribution/*.swift"
+
+  spec.dependency 'KovaleeSDK'
+  spec.dependency "Adjust", "~> 5.0.0"
+
+end

--- a/KovaleePurchases.podspec
+++ b/KovaleePurchases.podspec
@@ -1,0 +1,37 @@
+#
+#  Be sure to run `pod spec lint KovaleePurchases.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see https://guides.cocoapods.org/syntax/podspec.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |spec|
+  spec.name         = "KovaleePurchases"
+  spec.version      = "2.0.0"
+  spec.summary      = "KovaleePurchases simplify in-app purchases and subscriptions"
+  spec.description  = <<-DESC
+  Adding in-app purchases and subscriptions doesn't need to be a headache. KovaleePurchases comes with a set of APIs designed to streamline this integration.
+It's part of a broader project KovaleeSDK
+                   DESC
+
+  spec.license      = { :type => 'MIT', :file => 'MIT-LICENSE' }
+  spec.homepage     = "https://github.com/cotyapps/KovaleePurchases-iOS"
+  spec.author       = { "fto-k" => "fto@kovalee.app" }
+
+  spec.source       = { :git => "https://github.com/cotyapps/Kovalee-iOS-SDK.git", :tag => "#{spec.version}" }
+
+  spec.ios.deployment_target = '14.3'
+  spec.swift_version         = '5.7'
+  spec.source_files          = "Sources/KovaleePurchases/*.swift"
+
+  spec.dependency 'KovaleeSDK'
+  spec.dependency "RevenueCat", '>= 4.38.0'
+  spec.dependency "KovaleeRemoteConfig"
+
+  spec.static_framework = true
+
+  spec.dependency 'Firebase/Core', '>= 10.24.0'
+  spec.dependency "FirebaseAnalyticsSwift"
+  spec.dependency "FirebaseRemoteConfigSwift"
+end

--- a/KovaleePurchases.podspec
+++ b/KovaleePurchases.podspec
@@ -16,7 +16,7 @@ It's part of a broader project KovaleeSDK
                    DESC
 
   spec.license      = { :type => 'MIT', :file => 'MIT-LICENSE' }
-  spec.homepage     = "https://github.com/cotyapps/KovaleePurchases-iOS"
+  spec.homepage     = "https://github.com/cotyapps/Kovalee-iOS-SDK.git"
   spec.author       = { "fto-k" => "fto@kovalee.app" }
 
   spec.source       = { :git => "https://github.com/cotyapps/Kovalee-iOS-SDK.git", :tag => "#{spec.version}" }

--- a/KovaleeRemoteConfig.podspec
+++ b/KovaleeRemoteConfig.podspec
@@ -1,0 +1,36 @@
+#
+#  Be sure to run `pod spec lint KovaleeRemoteConfig.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see https://guides.cocoapods.org/syntax/podspec.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |spec|
+  spec.name         = "KovaleeRemoteConfig"
+  spec.version      = "2.0.0"
+  spec.summary      = "KovaleeRemoteConfig simplifies AB testing experiments."
+  spec.description  = <<-DESC
+  Unsure about how to present a feature? KovaleeRemoteConfig simplifies AB testing, helping you figure out the most user-friendly way to show off your new feature and optimize old ones.
+It's part of a broader project KovaleeSDK
+                   DESC
+
+  spec.license      = { :type => 'MIT', :file => 'MIT-LICENSE' }
+  spec.homepage     = "https://github.com/cotyapps/KovaleeRemoteConfig-iOS"
+  spec.author       = { "fto-k" => "fto@kovalee.app" }
+
+  spec.source       = { :git => "https://github.com/cotyapps/Kovalee-iOS-SDK.git", :tag => "#{spec.version}" }
+
+  spec.ios.deployment_target = '14.3'
+  spec.swift_version    = '5.7'
+  spec.source_files  = "Sources/KovaleeRemoteConfig/*.swift"
+
+  spec.dependency 'KovaleeSDK'
+
+  spec.static_framework = true
+
+  spec.dependency 'Firebase/Core', '>= 10.24.0'
+  spec.dependency "FirebaseAnalyticsSwift"
+  spec.dependency "FirebaseRemoteConfigSwift"
+
+end

--- a/KovaleeRemoteConfig.podspec
+++ b/KovaleeRemoteConfig.podspec
@@ -16,7 +16,7 @@ It's part of a broader project KovaleeSDK
                    DESC
 
   spec.license      = { :type => 'MIT', :file => 'MIT-LICENSE' }
-  spec.homepage     = "https://github.com/cotyapps/KovaleeRemoteConfig-iOS"
+  spec.homepage     = "https://github.com/cotyapps/Kovalee-iOS-SDK.git"
   spec.author       = { "fto-k" => "fto@kovalee.app" }
 
   spec.source       = { :git => "https://github.com/cotyapps/Kovalee-iOS-SDK.git", :tag => "#{spec.version}" }

--- a/KovaleeSDK.podspec
+++ b/KovaleeSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'KovaleeSDK'
-  s.version          = '1.12.5'
+  s.version          = '2.0.0'
   s.summary          = 'KovaleeSDK is an efficient iOS framework, that\'s packed with tools for tracking user behavior.'
   s.description  = <<-DESC
                    KovaleeSDK is an efficient iOS framework, that\'s packed with tools specifically for tracking user behavior, handling user purchases, and smoothly integrating ads.

--- a/KovaleeSDK.podspec
+++ b/KovaleeSDK.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
                    KovaleeSDK is an efficient iOS framework, that\'s packed with tools specifically for tracking user behavior, handling user purchases, and smoothly integrating ads.
                    DESC
 
-  s.license          = 'Code is MIT, then custom font licenses.'
+  s.license          = { :type => 'MIT', :file => 'MIT-LICENSE' }
   s.homepage         = 'https://github.com/cotyapps/Kovalee-iOS-SDK'
   s.author           = { 'FT' => 'fto@kovalee.app' }
 

--- a/KovaleeSDKUI.podspec
+++ b/KovaleeSDKUI.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
                    KovaleeSDKUI is an efficient iOS framework, that\'s packed with tools specifically for tracking user behavior, handling user purchases, and smoothly integrating ads.
                    DESC
 
-  s.license          = 'Code is MIT, then custom font licenses.'
+  s.license          = { :type => 'MIT', :file => 'MIT-LICENSE' }
   s.homepage         = 'https://github.com/cotyapps/Kovalee-iOS-SDK'
   s.author           = { 'FT' => 'fto@kovalee.app' }
 

--- a/KovaleeSDKUI.podspec
+++ b/KovaleeSDKUI.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'KovaleeSDKUI'
-  s.version          = '1.12.3'
+  s.version          = '2.0.0'
   s.summary          = 'KovaleeSDKUI is an efficient iOS framework, that\'s packed with tools for tracking user behavior.'
   s.description  = <<-DESC
                    KovaleeSDKUI is an efficient iOS framework, that\'s packed with tools specifically for tracking user behavior, handling user purchases, and smoothly integrating ads.

--- a/KovaleeSurvey.podspec
+++ b/KovaleeSurvey.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
                      KovaleeSurvey is an efficient iOS framework, that\'s packed with tools specifically for tracking user behavior, handling user purchases, and smoothly integrating ads.
                      DESC
   
-    s.license          = 'Code is MIT, then custom font licenses.'
+    s.license          = { :type => 'MIT', :file => 'MIT-LICENSE' }
     s.homepage         = 'https://github.com/cotyapps/Kovalee-iOS-SDK'
     s.author           = { 'FT' => 'fto@kovalee.app' }
   

--- a/KovaleeSurvey.podspec
+++ b/KovaleeSurvey.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name             = 'KovaleeSurvey'
-    s.version          = '1.10.0'
+    s.version          = '2.0.0'
     s.summary          = 'KovaleeSurvey is an efficient iOS framework, that\'s packed with tools for tracking user behavior.'
     s.description  = <<-DESC
                      KovaleeSurvey is an efficient iOS framework, that\'s packed with tools specifically for tracking user behavior, handling user purchases, and smoothly integrating ads.

--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,0 +1,21 @@
+Copyright (c) 2020-Present Kovalee,
+http://www.kovalee.app
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/Sources/KovaleePurchases/RevenueCatWrapperImpl.swift
+++ b/Sources/KovaleePurchases/RevenueCatWrapperImpl.swift
@@ -3,7 +3,6 @@ import KovaleeFramework
 import KovaleeRemoteConfig
 import KovaleeSDK
 import RevenueCat
-import SuperwallKit
 
 class RevenueCatWrapperImpl: NSObject, PurchaseManager, Manager {
     init(withKeys keys: KovaleeKeys.RevenueCat) {
@@ -37,9 +36,6 @@ class RevenueCatWrapperImpl: NSObject, PurchaseManager, Manager {
 
     func setUserId(userId: String) async throws -> (AbstractCustomerInfo, created: Bool) {
         let result = try await Purchases.shared.logIn(userId)
-        if Superwall.isInitialized {
-            Superwall.shared.identify(userId: Purchases.shared.appUserID)
-        }
         return (CustomerInfo(info: result.customerInfo), result.created)
     }
 


### PR DESCRIPTION
### 📝 Description

This PR adds and updates the missing podspec files for each target and the `MIT-LICENSE`.

### ⚒️ Changes

- Add `KovaleeAttribution.podspec`
- Add `KovaleePurchases.podspec`
- Add `KovaleeRemoteConfig.podspec`
- Add `MIT-LICENSE`
- Update `KovaleeSDK.podspec`
- Update `KovaleeSDKUI.podspec`
- Update `KovaleeSurvey.podspec
- Update `RevenueCatWrapperImpl`: Remove Superwall dependency