### PR TITLE
Fix: add sdk dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -74,6 +74,7 @@ let package = Package(
         .target(
             name: .kovaleeRemoteConfig,
             dependencies: [
+                .sdk,
                 .framework,
                 .firebaseAnalyticsSwift,
                 .firebaseRemoteConfig,


### PR DESCRIPTION
### 📝 Description

This PR adds the `sdk` dependency to the `RemoteConfig` target.