### PR TITLE
Manual TikTok event tracking

### DIFF
--- a/Sources/KovaleePurchases/RevenueCatWrapperImpl.swift
+++ b/Sources/KovaleePurchases/RevenueCatWrapperImpl.swift
@@ -170,10 +170,15 @@ final class RevenueCatWrapperImpl: NSObject, PurchaseManager, Manager {
         let purchaseResult = try await Purchases.shared.purchase(package: rcPackage)
         KLogger.debug("🛍️ Purchase \(purchaseResult)")
 
+        let product = rcPackage.storeProduct
         return KPurchaseResultData(
             transaction: KStoreTransaction(transaction: purchaseResult.transaction),
             customerInfo: KCustomerInfo(info: purchaseResult.customerInfo),
-            userCancelled: purchaseResult.userCancelled
+            userCancelled: purchaseResult.userCancelled,
+            productId: product.productIdentifier,
+            priceDecimal: product.price,
+            currencyCode: product.currencyCode,
+            hasFreeTrial: product.introductoryDiscount?.paymentMode == .freeTrial
         )
     }
 
@@ -188,7 +193,11 @@ final class RevenueCatWrapperImpl: NSObject, PurchaseManager, Manager {
         return KPurchaseResultData(
             transaction: KStoreTransaction(transaction: purchaseResult.transaction),
             customerInfo: KCustomerInfo(info: purchaseResult.customerInfo),
-            userCancelled: purchaseResult.userCancelled
+            userCancelled: purchaseResult.userCancelled,
+            productId: product.productIdentifier,
+            priceDecimal: product.price,
+            currencyCode: product.currencyCode,
+            hasFreeTrial: product.introductoryDiscount?.paymentMode == .freeTrial
         )
     }
 

--- a/Sources/KovaleePurchases/StoreDataModel.swift
+++ b/Sources/KovaleePurchases/StoreDataModel.swift
@@ -828,6 +828,12 @@ public struct KPurchaseResultData: AbstractPurchaseResultData, Encodable, Sendab
     public var transaction: KStoreTransaction?
     public var customerInfo: KCustomerInfo
     public var userCancelled: Bool
+    public var productId: String
+    public var priceDecimal: Decimal
+    public var currencyCode: String?
+    public var hasFreeTrial: Bool
+    /// Convenience accessor for the underlying StoreKit transaction identifier.
+    public var transactionId: String? { transaction?.transactionIdentifier }
 }
 
 public enum KIntroEligibilityStatus: Int {

--- a/Sources/KovaleeSDKUI/DebugView.swift
+++ b/Sources/KovaleeSDKUI/DebugView.swift
@@ -1,4 +1,5 @@
 #if os(iOS)
+    import KovaleeFramework
     import KovaleeSDK
     import SwiftUI
 
@@ -56,6 +57,8 @@
             NavigationView {
                 List {
                     Text("SDK Version: \(SDK_VERSION)")
+                        .allowsHitTesting(false)
+                    Text("Framework Built: \(KovaleeConstants.frameworkBuildDate)")
                         .allowsHitTesting(false)
                     Toggle("Enable Debug Mode", isOn: $isDebugModeOn)
 

--- a/Sources/KovaleeTikTok/KovaleeTikTok.swift
+++ b/Sources/KovaleeTikTok/KovaleeTikTok.swift
@@ -80,4 +80,105 @@ public extension Kovalee {
     static func flushTikTokEvents() {
         TikTokWrapperRef.shared.wrapper?.flush()
     }
+
+    /// Track a TikTok standard Registration event
+    ///
+    /// Safe to call in apps that do not configure TikTok — the call is a no-op.
+    ///
+    /// - Parameters:
+    ///   - method: optional registration method (e.g. "email", "apple", "google")
+    static func trackTikTokRegistration(method: String? = nil) {
+        TikTokWrapperRef.shared.wrapper?.trackRegistration(method: method)
+    }
+
+    /// Track a TikTok standard StartTrial event
+    ///
+    /// Auto-fired by the SDK from `Kovalee.purchase(package:fromSource:)` and
+    /// `Kovalee.purchaseSubscription(withId:fromSource:)` when the product has a free trial.
+    /// Only call manually if bypassing those APIs.
+    ///
+    /// Safe to call in apps that do not configure TikTok — the call is a no-op.
+    ///
+    /// - Parameters:
+    ///   - productId: subscription product identifier
+    ///   - value: trial value (usually 0 or intro price) in the given currency
+    ///   - currency: ISO 4217 currency code (e.g. "USD")
+    ///   - transactionId: unique transaction identifier for server-side dedup
+    static func trackTikTokStartTrial(
+        productId: String,
+        value: Double,
+        currency: String,
+        transactionId: String? = nil
+    ) {
+        TikTokWrapperRef.shared.wrapper?.trackStartTrial(
+            productId: productId,
+            value: value,
+            currency: currency,
+            transactionId: transactionId
+        )
+    }
+
+    /// Track a TikTok standard Subscribe event
+    ///
+    /// Auto-fired by the SDK on every successful `Kovalee.purchase(package:fromSource:)` or
+    /// `Kovalee.purchaseSubscription(withId:fromSource:)`. Only call manually if bypassing
+    /// those APIs.
+    ///
+    /// Safe to call in apps that do not configure TikTok — the call is a no-op.
+    ///
+    /// - Parameters:
+    ///   - productId: subscription product identifier
+    ///   - value: subscription price in the given currency
+    ///   - currency: ISO 4217 currency code (e.g. "USD")
+    ///   - transactionId: unique transaction identifier for server-side dedup
+    static func trackTikTokSubscribe(
+        productId: String,
+        value: Double,
+        currency: String,
+        transactionId: String? = nil
+    ) {
+        TikTokWrapperRef.shared.wrapper?.trackSubscribe(
+            productId: productId,
+            value: value,
+            currency: currency,
+            transactionId: transactionId
+        )
+    }
+
+    /// Track a TikTok Purchase event (renewals, one-time purchases)
+    ///
+    /// Pass the StoreKit/RevenueCat transaction identifier as `transactionId` so TikTok
+    /// can dedupe repeated deliveries of the same transaction.
+    ///
+    /// Safe to call in apps that do not configure TikTok — the call is a no-op.
+    ///
+    /// - Parameters:
+    ///   - productId: product identifier
+    ///   - value: transaction price in the given currency
+    ///   - currency: ISO 4217 currency code (e.g. "USD")
+    ///   - transactionId: unique transaction identifier for dedup
+    static func trackTikTokPurchase(
+        productId: String,
+        value: Double,
+        currency: String,
+        transactionId: String? = nil
+    ) {
+        TikTokWrapperRef.shared.wrapper?.trackPurchase(
+            productId: productId,
+            value: value,
+            currency: currency,
+            transactionId: transactionId
+        )
+    }
+
+    /// Track a TikTok ViewContent event (e.g. paywall impression, product detail view)
+    ///
+    /// Safe to call in apps that do not configure TikTok — the call is a no-op.
+    ///
+    /// - Parameters:
+    ///   - contentId: identifier for the content being viewed (e.g. paywall id, product id)
+    ///   - contentType: category/type label (e.g. "paywall", "product")
+    static func trackTikTokViewContent(contentId: String? = nil, contentType: String? = nil) {
+        TikTokWrapperRef.shared.wrapper?.trackViewContent(contentId: contentId, contentType: contentType)
+    }
 }

--- a/Sources/KovaleeTikTok/TikTokWrapperImpl.swift
+++ b/Sources/KovaleeTikTok/TikTokWrapperImpl.swift
@@ -39,6 +39,10 @@ final class TikTokWrapperRef: @unchecked Sendable {
                 return
             }
 
+            config.disableRetentionTracking()
+            config.disablePaymentTracking()
+            config.disableAutoEnhancedDataPostbackEvent()
+
             if debugMode {
                 config.enableDebugMode()
             }
@@ -91,6 +95,56 @@ final class TikTokWrapperRef: @unchecked Sendable {
         func flush() {
             TikTokBusiness.explicitlyFlush()
         }
+
+        func trackRegistration(method: String?) {
+            let event = TikTokBaseEvent(eventName: TTEventName.registration.rawValue)
+            if let method {
+                event.addProperty(withKey: "registration_method", value: method)
+            }
+            TikTokBusiness.trackTTEvent(event)
+        }
+
+        func trackStartTrial(productId: String, value: Double, currency: String, transactionId: String?) {
+            let event = TikTokBaseEvent(
+                eventName: TTEventName.startTrial.rawValue,
+                eventId: transactionId ?? UUID().uuidString
+            )
+            event.addProperty(withKey: "content_id", value: productId)
+            event.addProperty(withKey: "value", value: value)
+            event.addProperty(withKey: "currency", value: currency)
+            TikTokBusiness.trackTTEvent(event)
+        }
+
+        func trackSubscribe(productId: String, value: Double, currency: String, transactionId: String?) {
+            let event = TikTokBaseEvent(
+                eventName: TTEventName.subscribe.rawValue,
+                eventId: transactionId ?? UUID().uuidString
+            )
+            event.addProperty(withKey: "content_id", value: productId)
+            event.addProperty(withKey: "value", value: value)
+            event.addProperty(withKey: "currency", value: currency)
+            TikTokBusiness.trackTTEvent(event)
+        }
+
+        func trackPurchase(productId: String, value: Double, currency: String, transactionId: String?) {
+            let event = TikTokPurchaseEvent(eventId: transactionId ?? UUID().uuidString)
+            event.addProperty(withKey: "content_id", value: productId)
+            event.addProperty(withKey: "content_type", value: "product")
+            event.addProperty(withKey: "currency", value: currency)
+            event.addProperty(withKey: "value", value: value)
+            TikTokBusiness.trackTTEvent(event)
+        }
+
+        func trackViewContent(contentId: String?, contentType: String?) {
+            let event = TikTokViewContentEvent(eventId: UUID().uuidString)
+            if let contentId {
+                event.addProperty(withKey: "content_id", value: contentId)
+            }
+            if let contentType {
+                event.addProperty(withKey: "content_type", value: contentType)
+            }
+            TikTokBusiness.trackTTEvent(event)
+        }
     }
 #else
     final class TikTokWrapperImpl: Manager, TikTokManager {
@@ -119,6 +173,21 @@ final class TikTokWrapperRef: @unchecked Sendable {
         }
 
         func flush() {
+        }
+
+        func trackRegistration(method: String?) {
+        }
+
+        func trackStartTrial(productId: String, value: Double, currency: String, transactionId: String?) {
+        }
+
+        func trackSubscribe(productId: String, value: Double, currency: String, transactionId: String?) {
+        }
+
+        func trackPurchase(productId: String, value: Double, currency: String, transactionId: String?) {
+        }
+
+        func trackViewContent(contentId: String?, contentType: String?) {
         }
     }
 #endif


### PR DESCRIPTION
## Summary
- Disables TikTok SDK's auto retention / payment / enhanced-postback tracking; replaced by Kovalee-framework-driven dispatch of StartTrial and Subscribe events from `Kovalee.purchase` / `Kovalee.purchaseSubscription`.
- Exposes manual TikTok trackers on `Kovalee`: `trackTikTokRegistration`, `trackTikTokStartTrial`, `trackTikTokSubscribe`, `trackTikTokPurchase`, `trackTikTokViewContent`. All safe no-ops when TikTok isn't configured.
- `KPurchaseResultData` now carries `productId`, `priceDecimal`, `currencyCode`, `hasFreeTrial`, `transactionId` so callers can pass them into the track APIs without refetching products.
- `DebugView` shows the framework build date.

Paired with internal framework changes:
- `kovalee/Kovalee-internal#142` (manual tracking impl)
- `kovalee/Kovalee-internal#144` (non-optional productId / priceDecimal on `AbstractPurchaseResultData`)

## Test plan
- [ ] Build against a consumer app that does not configure TikTok — purchase flow behaves as before, no TikTok events fired.
- [ ] Build against a consumer app that does configure TikTok — `Kovalee.purchase(...)` dispatches Subscribe (and StartTrial when the product has a free trial) with a stable `eventId`.
- [ ] Verify TikTok dashboard receives dedupable events keyed by transaction id.
- [ ] `swift build` passes on all target platforms.