### PR TITLE
:sparkles: SubscriptionUpsell: trial-to-lifetime paywall flow

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -76,6 +76,10 @@ let package = Package(
             dependencies: [
                 .sdk,
                 .kovaleePurchases,
+                .revenueCatUI,
+            ],
+            resources: [
+                .process("Resources"),
             ]
         ),
         .target(
@@ -195,6 +199,14 @@ extension Target.Dependency {
             name: "RevenueCat",
             package: "purchases-ios-spm",
             condition: .when(platforms: [.macOS, .watchOS, .tvOS, .iOS, .visionOS])
+        )
+    }
+
+    static var revenueCatUI: Self {
+        .product(
+            name: "RevenueCatUI",
+            package: "purchases-ios-spm",
+            condition: .when(platforms: [.macOS, .tvOS, .iOS, .visionOS])
         )
     }
 

--- a/README.md
+++ b/README.md
@@ -149,3 +149,105 @@ Kovalee.setTikTokTrackingEnabled(false)
 // Flush queued events
 Kovalee.flushTikTokEvents()
 ```
+
+## Subscription Upsell
+
+KovaleeSDKUI ships a turnkey flow for users on an expiring free trial: detect the trial → present a RevenueCat-hosted upsell paywall (typically lifetime) → on purchase, route the user to Apple's *Manage Subscriptions* sheet so they can turn off auto-renewal on the original subscription (Apple does not allow developer-side cancellation).
+
+The host app never sees subscription state, paywall internals, or the manage-subscriptions sheet — it provides configuration and (optionally) receives the final outcome.
+
+### Setup
+
+1. Add the `KovaleeSDKUI` library to your app target. It depends on `RevenueCatUI`, which is fetched automatically.
+
+2. Build a `Configuration`:
+
+   ```swift
+   import KovaleeSDKUI
+
+   let upsellConfig = SubscriptionUpsell.Configuration(
+       offeringId: "lifetime_upsell",          // RevenueCat offering to present
+       trigger: .yearly,                        // watch for an expiring yearly trial
+       triggerWithin: 48 * 3600,                // …expiring within 48h (default: 48h, optional)
+       storageKey: "trial_to_lifetime_v1",      // namespace for the show-once flag
+       showCloseButton: false,                  // overlay an X if your paywall has no dismiss UI (default: false)
+       cancelPromptTheme: nil                   // use the default congrats-screen theme (default: nil)
+   )
+   ```
+
+   `offeringId`, `trigger`, and `storageKey` are required; everything else has a default. `trigger` can be `.yearly`, `.monthly`, `.weekly`, `.anySubscription`, or `.productIdentifiers([...])` for explicit product IDs.
+
+### Usage
+
+**SwiftUI** — drop the modifier on your root view. It runs the check on appear and on every foreground; the show-once flag (keyed by `storageKey`) keeps it idempotent.
+
+```swift
+ContentView()
+    .checkSubscriptionUpsell(configuration: upsellConfig) { outcome in
+        // .notTriggered | .dismissed | .purchased
+    }
+```
+
+**UIKit** — call from the view controller that should host the paywall:
+
+```swift
+SubscriptionUpsell.checkAndPresentIfNeeded(
+    configuration: upsellConfig,
+    from: self
+) { outcome in
+    // …
+}
+```
+
+**Deep link / marketing re-engagement** — bypass the trial-detection and show-once gates and present unconditionally. The built-in handler matches `<scheme>://upsell` (custom schemes only — `http`/`https` are refused):
+
+```swift
+func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+    guard let url = URLContexts.first?.url,
+          let root = scene.keyWindow?.rootViewController else { return }
+
+    if SubscriptionUpsell.handleDeepLink(url, configuration: upsellConfig, from: root) {
+        return
+    }
+    // …your other deep-link handlers
+}
+```
+
+Or present directly:
+
+```swift
+SubscriptionUpsell.presentNow(configuration: upsellConfig, from: presenter)
+```
+
+### Theming the congrats screen
+
+The post-purchase "Lifetime unlocked" screen is themable. Register a global default at launch so QA and debug previews match production:
+
+```swift
+SubscriptionUpsell.defaultCancelPromptTheme = SubscriptionUpsell.Theme(
+    background: .black,
+    iconTint: .yellow,
+    primaryButtonBackground: .yellow,
+    primaryButtonForeground: .black,
+    iconSystemName: "crown.fill"
+)
+```
+
+Per-call overrides take precedence via `Configuration.cancelPromptTheme`.
+
+### Debug / QA
+
+The SDK's `DebugView` exposes a *Subscription Upsell* section (visible when **Enable Debug Mode** is on) with:
+
+- **Force Trigger on Launch** — behaves as if a matching trial entitlement existed, regardless of subscription state. Gated to debug/TestFlight builds.
+- **Reset Shown State** — clears the show-once flag so the flow can fire again.
+- **Preview Congrats Screen** — opens the post-purchase screen directly to validate theming.
+
+### Outcomes
+
+| Outcome | Meaning |
+| --- | --- |
+| `.notTriggered` | No expiring trial, the flow already ran for this `storageKey`, or the offering / network lookup failed. |
+| `.dismissed` | The user closed the paywall without purchasing. |
+| `.purchased` | The upsell was purchased. Fires after the congrats screen is dismissed. |
+

--- a/README.md
+++ b/README.md
@@ -204,7 +204,8 @@ SubscriptionUpsell.checkAndPresentIfNeeded(
 ```swift
 func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
     guard let url = URLContexts.first?.url,
-          let root = scene.keyWindow?.rootViewController else { return }
+          let windowScene = scene as? UIWindowScene,
+          let root = windowScene.keyWindow?.rootViewController else { return }
 
     if SubscriptionUpsell.handleDeepLink(url, configuration: upsellConfig, from: root) {
         return

--- a/Sources/KovaleeSDKUI/DebugView.swift
+++ b/Sources/KovaleeSDKUI/DebugView.swift
@@ -60,7 +60,6 @@
                         .allowsHitTesting(false)
                     Text("Framework Built: \(KovaleeConstants.frameworkBuildDate)")
                         .allowsHitTesting(false)
-                    Toggle("Enable Debug Mode", isOn: $isDebugModeOn)
 
                     Section {
                         InfoLabel(title: "Current AB test Value:", value: abTestValue ?? "Not set yet")
@@ -96,6 +95,14 @@
                         Text("Purchases")
                     }
 
+                    if isDebugModeOn {
+                        Section {
+                            SubscriptionUpsellDebugView()
+                        } header: {
+                            Text("Subscription Upsell")
+                        }
+                    }
+
                     Section {
                         deepLinkView
                     } header: {
@@ -103,6 +110,9 @@
                     }
                 }
                 .allowsHitTesting(true)
+                .safeAreaInset(edge: .bottom) {
+                    debugModeFloatingBar
+                }
                 .task {
                     self.abTestValue = await Kovalee.shared.kovaleeManager?.abTestValue(forKey: Kovalee.abTestKey)
                     self.adid = await Kovalee.shared.kovaleeManager?.getAttributionAdid()
@@ -113,18 +123,30 @@
                     self.sessionCount = fetchSessionCount()
                     self.lastDeeplinkReceived = fetchLastOpenedURL()
                 }
-                .navigationTitle("SDK Debug Console")
                 .navigationBarTitleDisplayMode(.inline)
                 .onChange(of: isDebugModeOn) { _ in
                     Kovalee.shared.kovaleeManager?.setDebugMode(isDebugModeOn)
                 }
                 .toolbar {
-                    ToolbarItem(placement: .topBarTrailing) {
-                        Button("", systemImage: "xmark", role: .destructive) {
-                            dismiss()
+                    ToolbarItem(placement: .principal) {
+                        VStack(spacing: 2) {
+                            Text("Debug Console")
+                                .font(.headline)
+                            Text("Kovalee SDK · v\(SDK_VERSION)")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
                         }
-                        .bold()
-                        .tint(.black)
+                    }
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button {
+                            dismiss()
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .font(.system(size: 26))
+                                .symbolRenderingMode(.palette)
+                                .foregroundStyle(Color.secondary, Color(.tertiarySystemFill))
+                                .accessibilityLabel("Close")
+                        }
                     }
                 }
             }
@@ -133,6 +155,28 @@
 
     @available(iOS 16.0, *)
     extension DebugView {
+        private var debugModeFloatingBar: some View {
+            HStack(spacing: 12) {
+                Image(systemName: isDebugModeOn ? "ladybug.fill" : "ladybug")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundStyle(isDebugModeOn ? .green : .secondary)
+                Toggle("Enable Debug Mode", isOn: $isDebugModeOn)
+                    .font(.subheadline.weight(.medium))
+                    .tint(.green)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .overlay(
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .strokeBorder(Color.primary.opacity(0.08), lineWidth: 1)
+            )
+            .shadow(color: .black.opacity(0.18), radius: 14, x: 0, y: 6)
+            .padding(.horizontal, 16)
+            .padding(.bottom, 8)
+        }
+
+
         @ViewBuilder
         private var basicInfoView: some View {
             InfoLabel(

--- a/Sources/KovaleeSDKUI/Resources/en.lproj/Localizable.strings
+++ b/Sources/KovaleeSDKUI/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,16 @@
+/* SubscriptionUpsell — post-purchase "Lifetime unlocked" confirmation step */
+"Lifetime unlocked" = "Lifetime unlocked";
+"Your lifetime access is now active." = "Your lifetime access is now active.";
+"OK" = "OK";
+
+/* SubscriptionUpsell — post-purchase "cancel auto-renewal" prompt step */
+"One last step" = "One last step";
+"Turn off auto-renewal on your existing subscription so the App Store doesn't charge you again." = "Turn off auto-renewal on your existing subscription so the App Store doesn't charge you again.";
+"Open subscription settings" = "Open subscription settings";
+"I'll do it later" = "I'll do it later";
+
+/* SubscriptionUpsell — error shown when no window scene is available to host the manage-subscriptions sheet */
+"No active window scene." = "No active window scene.";
+
+/* SubscriptionUpsell — VoiceOver label for the paywall close (X) button */
+"Close" = "Close";

--- a/Sources/KovaleeSDKUI/SubscriptionUpsell/LifetimeCancelYearlyView.swift
+++ b/Sources/KovaleeSDKUI/SubscriptionUpsell/LifetimeCancelYearlyView.swift
@@ -1,0 +1,284 @@
+import Foundation
+#if os(iOS)
+import SwiftUI
+import StoreKit
+import UIKit
+
+struct LifetimeCancelYearlyView: View {
+	@Environment(\.dismiss) private var dismiss
+	let theme: SubscriptionUpsell.Theme
+	let sourceProduct: Product?
+	/// Correlation for funnel analytics. `nil` when the screen is shown as a
+	/// standalone preview (debug menu) — no events are fired in that case.
+	let analyticsContext: SubscriptionUpsellAnalytics.Context?
+	let onDismiss: @MainActor () -> Void
+
+	@State private var step: Step = .confirmation
+	@State private var didCancelTrialRenewal: Bool = false
+	@State private var isLoading: Bool = false
+	@State private var errorMessage: String? = nil
+	@State private var initialWillAutoRenew: Bool? = nil
+	@State private var didFireDismiss: Bool = false
+
+	private enum Step {
+		case confirmation
+		case cancelPrompt
+	}
+
+	var body: some View {
+		ZStack {
+			theme.background.ignoresSafeArea()
+
+			switch step {
+			case .confirmation: confirmationStep
+			case .cancelPrompt: cancelPromptStep
+			}
+		}
+		.frame(maxWidth: .infinity, maxHeight: .infinity)
+		.animation(.easeInOut(duration: 0.25), value: step)
+		.task {
+			initialWillAutoRenew = await fetchWillAutoRenew()
+		}
+		.task(id: didCancelTrialRenewal) {
+			guard didCancelTrialRenewal else { return }
+			try? await Task.sleep(nanoseconds: 450_000_000)
+			fireDismissOnce()
+		}
+	}
+
+
+	private var confirmationStep: some View {
+		VStack(spacing: 24) {
+			Spacer()
+
+			Image(systemName: theme.iconSystemName)
+				.font(.system(size: 56))
+				.foregroundStyle(theme.iconTint)
+
+			Text("Lifetime unlocked", bundle: .module)
+				.font(theme.titleFont)
+				.foregroundStyle(theme.titleColor)
+				.multilineTextAlignment(.center)
+
+			Text("Your lifetime access is now active.", bundle: .module)
+				.font(theme.bodyFont)
+				.multilineTextAlignment(.center)
+				.foregroundStyle(theme.bodyColor)
+				.padding(.horizontal, 24)
+
+			Spacer()
+
+			Button {
+				analyticsContext.map(SubscriptionUpsellAnalytics.confirmationOkTapped(in:))
+				step = .cancelPrompt
+			} label: {
+				Text("OK", bundle: .module)
+					.font(theme.buttonFont)
+					.foregroundStyle(theme.primaryButtonForeground)
+					.frame(maxWidth: .infinity)
+					.frame(height: 56)
+					.background(Capsule().fill(theme.primaryButtonBackground))
+			}
+			.padding(.horizontal, 24)
+			.padding(.bottom, 24)
+		}
+	}
+
+
+	private var cancelPromptStep: some View {
+		VStack(spacing: 24) {
+			Spacer()
+
+			Image(systemName: theme.cancelPromptIconSystemName)
+				.font(.system(size: 56))
+				.foregroundStyle(theme.iconTint)
+
+			Text("One last step", bundle: .module)
+				.font(theme.titleFont)
+				.foregroundStyle(theme.titleColor)
+				.multilineTextAlignment(.center)
+
+			Text("Turn off auto-renewal on your existing subscription so the App Store doesn't charge you again.", bundle: .module)
+				.font(theme.bodyFont)
+				.multilineTextAlignment(.center)
+				.foregroundStyle(theme.bodyColor)
+				.padding(.horizontal, 24)
+
+			if let errorMessage {
+				Text(errorMessage)
+					.font(.caption)
+					.foregroundStyle(.red)
+					.padding(.horizontal, 24)
+			}
+
+			Spacer()
+
+			Button {
+				analyticsContext.map(SubscriptionUpsellAnalytics.manageSubscriptionsOpened(in:))
+				Task { await openManageSubscriptions() }
+			} label: {
+				ZStack {
+					if isLoading {
+						ProgressView().tint(theme.primaryButtonForeground)
+					}
+					else {
+						Text("Open subscription settings", bundle: .module)
+					}
+				}
+				.font(theme.buttonFont)
+				.foregroundStyle(theme.primaryButtonForeground)
+				.frame(maxWidth: .infinity)
+				.frame(height: 56)
+				.background(Capsule().fill(theme.primaryButtonBackground))
+			}
+			.disabled(isLoading)
+			.padding(.horizontal, 24)
+
+			Button {
+				if let analyticsContext {
+					SubscriptionUpsellAnalytics.dismissedLater(in: analyticsContext, renewalCancelled: didCancelTrialRenewal)
+				}
+				fireDismissOnce()
+			} label: {
+				Text("I'll do it later", bundle: .module)
+					.font(.subheadline)
+					.foregroundStyle(theme.secondaryButtonColor)
+			}
+			.padding(.bottom, 24)
+		}
+	}
+
+
+	/// Dismisses the view and fires `onDismiss` exactly once. Multiple callers
+	/// (the "I'll do it later" button, the auto-dismiss after cancellation, the
+	/// no-source-product fallback) can race; this guard ensures the host's
+	/// completion callback isn't invoked twice.
+	@MainActor
+	private func fireDismissOnce() {
+		guard !didFireDismiss else { return }
+		didFireDismiss = true
+		dismiss()
+		onDismiss()
+	}
+
+
+	@MainActor
+	private func openManageSubscriptions() async {
+		errorMessage = nil
+		isLoading = true
+		// `defer` bodies are synchronous, so we kick off a Task to do the
+		// post-sheet renewal check on every exit path (success, no-scene,
+		// sheet error). The `.task(id: didCancelTrialRenewal)` handler
+		// then drives the auto-dismiss through `fireDismissOnce()`.
+		defer {
+			Task { @MainActor in
+				guard let current = await fetchWillAutoRenew() else {
+					didCancelTrialRenewal = true
+					isLoading = false
+					return
+				}
+				if initialWillAutoRenew == true, current == false {
+					if !didCancelTrialRenewal {
+						analyticsContext.map(SubscriptionUpsellAnalytics.renewalCancellationDetected(in:))
+					}
+					didCancelTrialRenewal = true
+				}
+				isLoading = false
+			}
+		}
+
+		// Hydrate the baseline before opening the sheet — the `.task`-driven
+		// fetch may not have completed yet if the user taps quickly. Without
+		// this, the post-sheet check sees a nil baseline and can't tell whether
+		// auto-renew was toggled off.
+		if initialWillAutoRenew == nil, sourceProduct != nil {
+			initialWillAutoRenew = await fetchWillAutoRenew()
+		}
+
+		guard let scene = Self.currentForegroundScene() else {
+			errorMessage = String(localized: "No active window scene.", bundle: .module)
+			return
+		}
+		do {
+			try await AppStore.showManageSubscriptions(in: scene)
+		}
+		catch {
+			errorMessage = error.localizedDescription
+			return
+		}
+	}
+
+	private func fetchWillAutoRenew() async -> Bool? {
+		guard let product = sourceProduct, let subscription = product.subscription else { return nil }
+		do {
+			let statuses = try await subscription.status
+			for status in statuses {
+				guard case .verified(let renewalInfo) = status.renewalInfo,
+				      case .verified(let transaction) = status.transaction,
+				      transaction.productID == product.id
+				else { continue }
+				return renewalInfo.willAutoRenew
+			}
+			return nil
+		}
+		catch {
+			return nil
+		}
+	}
+
+
+	@MainActor
+	private static func currentForegroundScene() -> UIWindowScene? {
+		UIApplication.shared.connectedScenes
+			.compactMap { $0 as? UIWindowScene }
+			.first { $0.activationState == .foregroundActive }
+			?? UIApplication.shared.connectedScenes
+				.compactMap { $0 as? UIWindowScene }
+				.first
+	}
+}
+
+
+extension LifetimeCancelYearlyView {
+
+	@MainActor
+	static func launchAtTop(
+		theme: SubscriptionUpsell.Theme,
+		sourceProduct: Product? = nil,
+		analyticsContext: SubscriptionUpsellAnalytics.Context? = nil,
+		onDismiss: @escaping @MainActor () -> Void
+	) {
+		guard let topPresenter = Self.topPresenter else {
+			onDismiss()
+			return
+		}
+		let host = UIHostingController(
+			rootView: LifetimeCancelYearlyView(
+				theme: theme,
+				sourceProduct: sourceProduct,
+				analyticsContext: analyticsContext,
+				onDismiss: onDismiss
+			)
+		)
+		host.modalPresentationStyle = .fullScreen
+		topPresenter.present(host, animated: true)
+	}
+
+
+	@MainActor
+	private static var topPresenter: UIViewController? {
+		let scene = UIApplication.shared.connectedScenes
+			.compactMap { $0 as? UIWindowScene }
+			.first { $0.activationState == .foregroundActive }
+			?? UIApplication.shared.connectedScenes
+				.compactMap { $0 as? UIWindowScene }
+				.first
+		guard let root = scene?.keyWindow?.rootViewController else { return nil }
+		var top = root
+		while let presented = top.presentedViewController {
+			top = presented
+		}
+		return top
+	}
+}
+#endif

--- a/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsell+SwiftUI.swift
+++ b/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsell+SwiftUI.swift
@@ -1,0 +1,64 @@
+import Foundation
+#if os(iOS)
+import SwiftUI
+import UIKit
+
+public extension View {
+
+	/// Runs the SubscriptionUpsell check when the view appears (and again on
+	/// each foreground), idempotent via the configuration's storage key.
+	///
+	/// SwiftUI counterpart to ``SubscriptionUpsell/checkAndPresentIfNeeded(configuration:from:onCompletion:)``.
+	func checkSubscriptionUpsell(
+		configuration: SubscriptionUpsell.Configuration,
+		onCompletion: (@MainActor @Sendable (SubscriptionUpsell.Outcome) -> Void)? = nil
+	) -> some View {
+		modifier(SubscriptionUpsellModifier(configuration: configuration, onCompletion: onCompletion))
+	}
+}
+
+
+private struct SubscriptionUpsellModifier: ViewModifier {
+	let configuration: SubscriptionUpsell.Configuration
+	let onCompletion: (@MainActor @Sendable (SubscriptionUpsell.Outcome) -> Void)?
+
+	@Environment(\.scenePhase) private var scenePhase
+
+	func body(content: Content) -> some View {
+		content
+			.task(id: scenePhase) {
+				if scenePhase == .active {
+					runCheck()
+				}
+			}
+	}
+
+
+	@MainActor
+	private func runCheck() {
+		SubscriptionUpsellPresenter.run(
+			configuration: configuration,
+			present: { viewController in
+				guard let presenter = SubscriptionUpsellModifier.topPresenter else { return false }
+				presenter.present(viewController, animated: true)
+				return true
+			},
+			onCompletion: onCompletion
+		)
+	}
+
+
+	@MainActor
+	private static var topPresenter: UIViewController? {
+		let scene = UIApplication.shared.connectedScenes
+			.compactMap { $0 as? UIWindowScene }
+			.first { $0.activationState == .foregroundActive }
+		guard let root = scene?.keyWindow?.rootViewController else { return nil }
+		var top = root
+		while let presented = top.presentedViewController {
+			top = presented
+		}
+		return top
+	}
+}
+#endif

--- a/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsell.swift
+++ b/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsell.swift
@@ -8,8 +8,8 @@ import SwiftUI
 /// Host apps configure with the RevenueCat offering to present and the product
 /// identifiers that count as the source subscription. The SDK then:
 ///
-/// 1. Checks for an active trial entitlement matching `triggerProductIdentifiers`
-///    whose expiration is within `triggerWithin`.
+/// 1. Checks for an active trial entitlement matching the product identifiers
+///    that `trigger` resolves to, whose expiration is within `triggerWithin`.
 /// 2. Verifies the flow hasn't been shown before (idempotent per `storageKey`).
 /// 3. Presents the RC-hosted paywall for `offeringId`.
 /// 4. On successful purchase, presents a screen that opens Apple's
@@ -60,8 +60,11 @@ public enum SubscriptionUpsell {
 		/// install.
 		public let storageKey: String
 
-		/// Skip the trial-detection and show-once checks and present the paywall
-		/// unconditionally. For QA / screenshots only — ship with `false`.
+		/// Skip trial-detection and present the paywall as if a matching trial
+		/// were expiring. The show-once gate still applies — once presented for
+		/// this `storageKey` the flow won't run again until the flag is cleared
+		/// via `SubscriptionUpsellOverride.clearAllShownStates()`. For QA /
+		/// screenshots only — ship with `false`.
 		public let debugForceTrigger: Bool
 
 		/// Overlays a top-leading X close button on the paywall, independent of
@@ -205,7 +208,7 @@ public enum SubscriptionUpsell {
 		theme: Theme? = nil,
 		onCompletion: (@MainActor @Sendable () -> Void)? = nil
 	) {
-		LifetimeCancelYearlyView.launchAtTop(theme: theme ?? defaultCancelPromptTheme) {
+		UpsellPostPurchaseView.launchAtTop(theme: theme ?? defaultCancelPromptTheme) {
 			onCompletion?()
 		}
 	}

--- a/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsell.swift
+++ b/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsell.swift
@@ -1,0 +1,249 @@
+import Foundation
+#if os(iOS)
+import UIKit
+import SwiftUI
+
+/// Drives a "trial-ending → upsell paywall → cancel-original-subscription" flow.
+///
+/// Host apps configure with the RevenueCat offering to present and the product
+/// identifiers that count as the source subscription. The SDK then:
+///
+/// 1. Checks for an active trial entitlement matching `triggerProductIdentifiers`
+///    whose expiration is within `triggerWithin`.
+/// 2. Verifies the flow hasn't been shown before (idempotent per `storageKey`).
+/// 3. Presents the RC-hosted paywall for `offeringId`.
+/// 4. On successful purchase, presents a screen that opens Apple's
+///    manage-subscriptions sheet so the user can turn off auto-renewal on the
+///    original subscription (Apple does not allow developer-side cancellation).
+///
+/// The host app never sees subscription state, paywall internals, or the
+/// manage-subscriptions sheet — it provides configuration and (optionally)
+/// receives the final outcome.
+public enum SubscriptionUpsell {
+
+	/// Theme used by `presentCongratsScreen` and by the SDK debug-menu preview.
+	/// Hosts can override at launch (e.g. `SubscriptionUpsell.defaultCancelPromptTheme = .pep`)
+	/// so QA sees the production look-and-feel in previews. Per-call Configuration
+	/// theme still takes precedence inside the real upsell flow.
+	@MainActor
+	public static var defaultCancelPromptTheme: Theme = .default
+
+
+	/// Which source subscription(s) to watch. The SDK resolves the actual
+	/// product identifiers from RC's offerings at evaluation time.
+	public enum Trigger: Sendable, Equatable {
+		/// Any annual subscription discovered in RC offerings.
+		case yearly
+		/// Any monthly subscription.
+		case monthly
+		/// Any weekly subscription.
+		case weekly
+		/// Any subscription regardless of period.
+		case anySubscription
+		/// Explicit product identifiers. Use when you need to scope to specific
+		/// product IDs rather than a period bucket.
+		case productIdentifiers(Set<String>)
+	}
+
+	public struct Configuration: Sendable {
+		/// RevenueCat offering identifier rendered as the upsell paywall.
+		public let offeringId: String
+
+		/// Which source subscription(s) to watch for an expiring trial.
+		public let trigger: Trigger
+
+		/// Time window before trial expiration during which to trigger.
+		public let triggerWithin: TimeInterval
+
+		/// Namespace key used to remember "already shown" state. Reusing the
+		/// same key across runs / sessions guarantees the flow shows once per
+		/// install.
+		public let storageKey: String
+
+		/// Skip the trial-detection and show-once checks and present the paywall
+		/// unconditionally. For QA / screenshots only — ship with `false`.
+		public let debugForceTrigger: Bool
+
+		/// Overlays a top-leading X close button on the paywall, independent of
+		/// the RC paywall template. Leave `false` if your RC paywall already
+		/// has a button with the close action designed into it. Enable when
+		/// the paywall has no dismiss UI of its own.
+		public let showCloseButton: Bool
+
+		/// Visual customization for the post-purchase "Lifetime unlocked"
+		/// screen. When `nil` the orchestrator falls back to
+		/// `SubscriptionUpsell.defaultCancelPromptTheme` (which hosts can
+		/// register once at launch). Pass an explicit `Theme` to override.
+		public let cancelPromptTheme: Theme?
+
+		public init(
+			offeringId: String,
+			trigger: Trigger,
+			triggerWithin: TimeInterval = 48 * 3600,
+			storageKey: String,
+			debugForceTrigger: Bool = false,
+			showCloseButton: Bool = false,
+			cancelPromptTheme: Theme? = nil
+		) {
+			self.offeringId = offeringId
+			self.trigger = trigger
+			self.triggerWithin = triggerWithin
+			self.storageKey = storageKey
+			self.debugForceTrigger = debugForceTrigger
+			self.showCloseButton = showCloseButton
+			self.cancelPromptTheme = cancelPromptTheme
+		}
+	}
+
+	public enum Outcome: Sendable, Equatable {
+		case notTriggered
+		case dismissed
+		case purchased
+	}
+
+
+	/// Visual customization for the post-purchase "Lifetime unlocked" screen.
+	/// Defaults to system styling so any host gets a sensible look without
+	/// configuration.
+	public struct Theme: Sendable {
+		public var background: Color
+		public var iconTint: Color
+		public var titleColor: Color
+		public var bodyColor: Color
+		public var primaryButtonBackground: Color
+		public var primaryButtonForeground: Color
+		public var secondaryButtonColor: Color
+		public var titleFont: Font
+		public var bodyFont: Font
+		public var buttonFont: Font
+		/// SF Symbol shown above the "Lifetime unlocked" confirmation step.
+		public var iconSystemName: String
+		/// SF Symbol shown above the "One last step" cancel-prompt step. Kept
+		/// separate from `iconSystemName` so the celebratory icon doesn't carry
+		/// over into the more cautionary "turn off auto-renewal" screen.
+		public var cancelPromptIconSystemName: String
+
+		public init(
+			background: Color = Color(.systemBackground),
+			iconTint: Color = .accentColor,
+			titleColor: Color = .primary,
+			bodyColor: Color = .secondary,
+			primaryButtonBackground: Color = .accentColor,
+			primaryButtonForeground: Color = .white,
+			secondaryButtonColor: Color = .secondary,
+			titleFont: Font = .system(size: 32, weight: .semibold),
+			bodyFont: Font = .body,
+			buttonFont: Font = .headline,
+			iconSystemName: String = "checkmark.seal.fill",
+			cancelPromptIconSystemName: String = "exclamationmark.circle.fill"
+		) {
+			self.background = background
+			self.iconTint = iconTint
+			self.titleColor = titleColor
+			self.bodyColor = bodyColor
+			self.primaryButtonBackground = primaryButtonBackground
+			self.primaryButtonForeground = primaryButtonForeground
+			self.secondaryButtonColor = secondaryButtonColor
+			self.titleFont = titleFont
+			self.bodyFont = bodyFont
+			self.buttonFont = buttonFont
+			self.iconSystemName = iconSystemName
+			self.cancelPromptIconSystemName = cancelPromptIconSystemName
+		}
+
+		public static let `default` = Theme()
+	}
+
+	/// UIKit entry point.
+	///
+	/// Idempotent: safe to call repeatedly (e.g. from every foreground). The
+	/// flow runs at most once per `configuration.storageKey`.
+	@MainActor
+	public static func checkAndPresentIfNeeded(
+		configuration: Configuration,
+		from presenter: UIViewController,
+		onCompletion: (@MainActor @Sendable (Outcome) -> Void)? = nil
+	) {
+		SubscriptionUpsellPresenter.run(
+			configuration: configuration,
+			present: { [weak presenter] viewController in
+				guard let presenter else { return false }
+				presenter.present(viewController, animated: true)
+				return true
+			},
+			onCompletion: onCompletion
+		)
+	}
+
+
+	/// Force-presents the upsell paywall right now, bypassing trial detection
+	/// and the show-once gate. For deep links (e.g. `peptalk://upsell`) and
+	/// marketing re-engagement.
+	@MainActor
+	public static func presentNow(
+		configuration: Configuration,
+		from presenter: UIViewController,
+		onCompletion: (@MainActor @Sendable (Outcome) -> Void)? = nil
+	) {
+		SubscriptionUpsellPresenter.runForced(
+			configuration: configuration,
+			present: { [weak presenter] viewController in
+				guard let presenter else { return false }
+				presenter.present(viewController, animated: true)
+				return true
+			},
+			onCompletion: onCompletion
+		)
+	}
+
+
+	/// Presents the "Lifetime unlocked" congrats screen directly. Useful for
+	/// debug menu previews, design reviews, and QA without needing a real
+	/// purchase. Uses `defaultCancelPromptTheme` unless overridden.
+	@MainActor
+	public static func presentCongratsScreen(
+		theme: Theme? = nil,
+		onCompletion: (@MainActor @Sendable () -> Void)? = nil
+	) {
+		LifetimeCancelYearlyView.launchAtTop(theme: theme ?? defaultCancelPromptTheme) {
+			onCompletion?()
+		}
+	}
+
+
+	/// Routes `<scheme>://upsell` deep links to the upsell flow. Scheme-agnostic
+	/// for custom schemes — matches on host/path so each host app can keep its
+	/// own URL scheme.
+	///
+	/// ### What matches
+	/// - `<scheme>://upsell`
+	/// - `<scheme>://upsell/`
+	/// - `<scheme>:///upsell` (hostless variant — path-only)
+	///
+	/// ### What does NOT match
+	/// - `<scheme>://app/upsell` — `upsell` must be the host (or be the entire
+	///   path in the hostless variant), not nested under another host.
+	/// - `<scheme>://upsell/foo` — extra path segments are rejected.
+	/// - `http://...` / `https://...` — refused so universal links with an
+	///   unrelated `/upsell` path don't accidentally trigger the paywall.
+	///
+	/// - Returns: `true` if the URL was matched and the paywall is being
+	///            presented, so the caller can short-circuit its other
+	///            deep-link handlers.
+	@MainActor
+	public static func handleDeepLink(
+		_ url: URL,
+		configuration: Configuration,
+		from presenter: UIViewController,
+		onCompletion: (@MainActor @Sendable (Outcome) -> Void)? = nil
+	) -> Bool {
+		let scheme = url.scheme?.lowercased() ?? ""
+		guard !scheme.isEmpty, scheme != "http", scheme != "https" else { return false }
+		let hostIsUpsell = url.host == "upsell" && (url.path.isEmpty || url.path == "/")
+		let hostlessUpsellPath = (url.host?.isEmpty ?? true) && url.path == "/upsell"
+		guard hostIsUpsell || hostlessUpsellPath else { return false }
+		presentNow(configuration: configuration, from: presenter, onCompletion: onCompletion)
+		return true
+	}
+}
+#endif

--- a/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsellAnalytics.swift
+++ b/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsellAnalytics.swift
@@ -1,0 +1,71 @@
+#if os(iOS)
+import Foundation
+import KovaleeSDK
+
+enum SubscriptionUpsellAnalytics {
+
+	enum Source: String {
+		case auto      // regular foreground / trial-detection path
+		case forced    // deep-link / presentNow path
+	}
+
+	/// Correlation context attached to every event in a single upsell flow so
+	/// the post-purchase funnel (confirmation → manage subs → dismiss) can be
+	/// joined back to the originating paywall in analytics.
+	struct Context {
+		let source: Source
+		let offeringId: String
+	}
+
+	static func paywallShown(in context: Context) {
+		Kovalee.sendEvent(withName: "subscription_upsell_paywall_shown", andProperties: [
+			"source": context.source.rawValue,
+			"offering_id": context.offeringId,
+		])
+	}
+
+	static func paywallClosed(in context: Context, purchased: Bool) {
+		Kovalee.sendEvent(withName: "subscription_upsell_paywall_closed", andProperties: [
+			"source": context.source.rawValue,
+			"offering_id": context.offeringId,
+			"purchased": purchased,
+		])
+	}
+
+	static func purchased(in context: Context) {
+		Kovalee.sendEvent(withName: "subscription_upsell_purchased", andProperties: [
+			"source": context.source.rawValue,
+			"offering_id": context.offeringId,
+		])
+	}
+
+	static func confirmationOkTapped(in context: Context) {
+		Kovalee.sendEvent(withName: "subscription_upsell_confirmation_ok_tapped", andProperties: [
+			"source": context.source.rawValue,
+			"offering_id": context.offeringId,
+		])
+	}
+
+	static func manageSubscriptionsOpened(in context: Context) {
+		Kovalee.sendEvent(withName: "subscription_upsell_manage_subs_opened", andProperties: [
+			"source": context.source.rawValue,
+			"offering_id": context.offeringId,
+		])
+	}
+
+	static func renewalCancellationDetected(in context: Context) {
+		Kovalee.sendEvent(withName: "subscription_upsell_renewal_cancelled_detected", andProperties: [
+			"source": context.source.rawValue,
+			"offering_id": context.offeringId,
+		])
+	}
+
+	static func dismissedLater(in context: Context, renewalCancelled: Bool) {
+		Kovalee.sendEvent(withName: "subscription_upsell_dismissed_later", andProperties: [
+			"source": context.source.rawValue,
+			"offering_id": context.offeringId,
+			"renewal_cancelled": renewalCancelled,
+		])
+	}
+}
+#endif

--- a/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsellOverride.swift
+++ b/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsellOverride.swift
@@ -1,0 +1,31 @@
+#if os(iOS)
+import Foundation
+
+/// Persistent overrides used by the SDK debug panel to drive the upsell flow
+/// for QA without code changes. Apply on every launch / foreground until
+/// toggled off in the debug menu.
+public enum SubscriptionUpsellOverride {
+
+	/// When `true`, the orchestrator behaves as if a matching trial entitlement
+	/// existed and presents the paywall regardless of subscription state or the
+	/// show-once flag. Equivalent to `Configuration(debugForceTrigger: true)`
+	/// without rebuilding the host app.
+	public static let forceTriggerKey = "kovalee.subscriptionUpsell.debugForceTrigger"
+
+	static var forceTrigger: Bool {
+		guard Config.isDebugOrTestflight else { return false }
+		return UserDefaults.standard.bool(forKey: forceTriggerKey)
+	}
+
+	/// Removes every show-once flag under the `kovalee.subscriptionUpsell.*`
+	/// namespace so the flow can fire again.
+	public static func clearAllShownStates() {
+		let defaults = UserDefaults.standard
+		for key in defaults.dictionaryRepresentation().keys where
+			key.hasPrefix("kovalee.subscriptionUpsell.") && key.hasSuffix(".shownAt")
+		{
+			defaults.removeObject(forKey: key)
+		}
+	}
+}
+#endif

--- a/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsellOverride.swift
+++ b/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsellOverride.swift
@@ -7,9 +7,10 @@ import Foundation
 public enum SubscriptionUpsellOverride {
 
 	/// When `true`, the orchestrator behaves as if a matching trial entitlement
-	/// existed and presents the paywall regardless of subscription state or the
-	/// show-once flag. Equivalent to `Configuration(debugForceTrigger: true)`
-	/// without rebuilding the host app.
+	/// existed and presents the paywall regardless of subscription state.
+	/// The show-once flag still applies — use `clearAllShownStates()` to
+	/// re-arm. Equivalent to `Configuration(debugForceTrigger: true)` without
+	/// rebuilding the host app.
 	public static let forceTriggerKey = "kovalee.subscriptionUpsell.debugForceTrigger"
 
 	static var forceTrigger: Bool {

--- a/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsellPresenter.swift
+++ b/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsellPresenter.swift
@@ -1,0 +1,302 @@
+import Foundation
+#if os(iOS)
+import UIKit
+import SwiftUI
+import StoreKit
+import KovaleeFramework
+import RevenueCat
+import RevenueCatUI
+
+enum SubscriptionUpsellPresenter {
+
+	/// Keys for which a `run` Task is currently executing. Used to suppress
+	/// duplicate invocations triggered close together (e.g. the SwiftUI
+	/// modifier's `task(id: scenePhase)` re-firing on rapid scene-phase
+	/// oscillation). Tracked separately from `inFlightForced` so a deep-link
+	/// `runForced` isn't blocked by an in-progress trial-detection `run`.
+	@MainActor
+	private static var inFlight: Set<String> = []
+
+	/// Keys for which a `runForced` Task is currently executing. Independent of
+	/// `inFlight` so the deliberate deep-link / `presentNow` path is never
+	/// suppressed by a concurrent `run`.
+	@MainActor
+	private static var inFlightForced: Set<String> = []
+
+
+	/// Generic entry that accepts a presentation closure so both UIKit and
+	/// SwiftUI hosts can drive the flow.
+	///
+	/// If another `run` / `runForced` is already in flight for the same
+	/// `storageKey`, this call is a no-op and `onCompletion` is not invoked
+	/// (the in-flight call owns the completion contract).
+	@MainActor
+	static func run(
+		configuration: SubscriptionUpsell.Configuration,
+		present: @escaping @MainActor (UIViewController) -> Bool,
+		onCompletion: (@MainActor @Sendable (SubscriptionUpsell.Outcome) -> Void)?
+	) {
+		let storage = UpsellStorage(key: configuration.storageKey)
+		if storage.hasShown {
+			onCompletion?(.notTriggered)
+			return
+		}
+		guard !inFlight.contains(configuration.storageKey) else { return }
+		inFlight.insert(configuration.storageKey)
+
+		let forceTrigger = configuration.debugForceTrigger || SubscriptionUpsellOverride.forceTrigger
+		let storageKey = configuration.storageKey
+
+		Task { @MainActor in
+			defer { inFlight.remove(storageKey) }
+			do {
+				let offerings = try await Purchases.shared.offerings()
+				let productIds = resolveProductIdentifiers(for: configuration.trigger, in: offerings)
+
+				let matchedProductId: String?
+				if forceTrigger {
+					matchedProductId = productIds.first
+				}
+				else {
+					guard let entitlement = try await findExpiringTrialEntitlement(
+						productIdentifiers: productIds,
+						within: configuration.triggerWithin
+					) else {
+						onCompletion?(.notTriggered)
+						return
+					}
+					matchedProductId = entitlement.productIdentifier
+				}
+
+				guard let offering = offerings.offering(identifier: configuration.offeringId) else {
+					KLogger.error("[SubscriptionUpsell] offering not found: \(configuration.offeringId)")
+					onCompletion?(.notTriggered)
+					return
+				}
+
+				let sourceProduct = await fetchSourceProduct(id: matchedProductId)
+
+				let context = SubscriptionUpsellAnalytics.Context(source: .auto, offeringId: configuration.offeringId)
+				let paywall = makePaywallController(
+					offering: offering,
+					sourceProduct: sourceProduct,
+					showCloseButton: configuration.showCloseButton,
+					cancelPromptTheme: configuration.cancelPromptTheme ?? SubscriptionUpsell.defaultCancelPromptTheme,
+					analyticsContext: context,
+					onCompletion: onCompletion
+				)
+				// Only consume the show-once budget if the host can actually
+				// present. If `present` returns false the paywall never
+				// reaches the screen and the host's completion would be
+				// orphaned (paywall callbacks never fire), so we synthesize
+				// `.notTriggered` here.
+				guard present(paywall) else {
+					onCompletion?(.notTriggered)
+					return
+				}
+				storage.markShown()
+				SubscriptionUpsellAnalytics.paywallShown(in: context)
+			}
+			catch {
+				KLogger.error("[SubscriptionUpsell] failed to evaluate trigger: \(error)")
+				onCompletion?(.notTriggered)
+			}
+		}
+	}
+
+
+	private static func fetchSourceProduct(id: String?) async -> Product? {
+		guard let id else { return nil }
+		do {
+			return try await Product.products(for: [id]).first
+		}
+		catch {
+			KLogger.error("[SubscriptionUpsell] failed to fetch StoreKit product \(id): \(error)")
+			return nil
+		}
+	}
+
+
+	/// Bypasses every gate (show-once, trial detection) and just presents the
+	/// paywall. Backing implementation for `SubscriptionUpsell.presentNow(...)`
+	/// and the deep-link entry point.
+	///
+	/// Independent of `run`'s in-flight tracking — a deep link arriving while
+	/// `run` is still doing its async trial check is never silently dropped.
+	/// Only dedupes back-to-back `runForced` calls for the same `storageKey`.
+	@MainActor
+	static func runForced(
+		configuration: SubscriptionUpsell.Configuration,
+		present: @escaping @MainActor (UIViewController) -> Bool,
+		onCompletion: (@MainActor @Sendable (SubscriptionUpsell.Outcome) -> Void)?
+	) {
+		guard !inFlightForced.contains(configuration.storageKey) else { return }
+		inFlightForced.insert(configuration.storageKey)
+		let storageKey = configuration.storageKey
+
+		Task { @MainActor in
+			defer { inFlightForced.remove(storageKey) }
+			do {
+				let offerings = try await Purchases.shared.offerings()
+				guard let offering = offerings.offering(identifier: configuration.offeringId) else {
+					KLogger.error("[SubscriptionUpsell] offering not found: \(configuration.offeringId)")
+					onCompletion?(.notTriggered)
+					return
+				}
+				let context = SubscriptionUpsellAnalytics.Context(source: .forced, offeringId: configuration.offeringId)
+				let paywall = makePaywallController(
+					offering: offering,
+					sourceProduct: nil,
+					showCloseButton: configuration.showCloseButton,
+					cancelPromptTheme: configuration.cancelPromptTheme ?? SubscriptionUpsell.defaultCancelPromptTheme,
+					analyticsContext: context,
+					onCompletion: onCompletion
+				)
+				guard present(paywall) else {
+					onCompletion?(.notTriggered)
+					return
+				}
+				SubscriptionUpsellAnalytics.paywallShown(in: context)
+			}
+			catch {
+				KLogger.error("[SubscriptionUpsell] presentNow failed: \(error)")
+				onCompletion?(.notTriggered)
+			}
+		}
+	}
+
+
+	private static func resolveProductIdentifiers(
+		for trigger: SubscriptionUpsell.Trigger,
+		in offerings: Offerings
+	) -> Set<String> {
+		if case .productIdentifiers(let ids) = trigger {
+			return ids
+		}
+		var ids = Set<String>()
+		for offering in offerings.all.values {
+			for package in offering.availablePackages {
+				let unit = package.storeProduct.subscriptionPeriod?.unit
+				if matches(trigger: trigger, unit: unit) {
+					ids.insert(package.storeProduct.productIdentifier)
+				}
+			}
+		}
+		return ids
+	}
+
+
+	private static func matches(trigger: SubscriptionUpsell.Trigger, unit: RevenueCat.SubscriptionPeriod.Unit?) -> Bool {
+		guard let unit else { return false }
+		switch trigger {
+			case .yearly: return unit == .year
+			case .monthly: return unit == .month
+			case .weekly: return unit == .week
+			case .anySubscription: return true
+			case .productIdentifiers: return false  // handled above
+		}
+	}
+
+
+	@MainActor
+	private static func makePaywallController(
+		offering: Offering,
+		sourceProduct: Product?,
+		showCloseButton: Bool,
+		cancelPromptTheme: SubscriptionUpsell.Theme,
+		analyticsContext: SubscriptionUpsellAnalytics.Context,
+		onCompletion: (@MainActor @Sendable (SubscriptionUpsell.Outcome) -> Void)?
+	) -> UIViewController {
+
+		let purchaseSignal = PurchaseSignal()
+		let view = PaywallView(offering: offering)
+			.onPurchaseCompleted { _ in
+				purchaseSignal.didPurchase = true
+				SubscriptionUpsellAnalytics.purchased(in: analyticsContext)
+			}
+			.onRequestedDismissal {
+				purchaseSignal.requestDismiss?()
+			}
+			.overlay(alignment: .topLeading) {
+				if showCloseButton {
+					Button {
+						purchaseSignal.requestDismiss?()
+					} label: {
+						Image(systemName: "xmark.circle.fill")
+							.font(.system(size: 28))
+							.symbolRenderingMode(.palette)
+							.foregroundStyle(Color.white.opacity(0.9), Color.black.opacity(0.5))
+					}
+					.accessibilityLabel(Text("Close", bundle: .module))
+					.padding(.leading, 16)
+					.padding(.top, 8)
+				}
+			}
+
+		let host = UIHostingController(rootView: view)
+		host.modalPresentationStyle = .fullScreen
+
+		// `[weak purchaseSignal]` breaks the self-retain cycle that would
+		// otherwise occur because the closure is stored on `purchaseSignal`
+		// itself (`purchaseSignal.requestDismiss = …`).
+		purchaseSignal.requestDismiss = { [weak host, weak purchaseSignal] in
+			guard let host, let purchaseSignal else { return }
+			let purchased = purchaseSignal.didPurchase
+			SubscriptionUpsellAnalytics.paywallClosed(in: analyticsContext, purchased: purchased)
+			host.dismiss(animated: true) {
+				if purchased {
+					LifetimeCancelYearlyView.launchAtTop(
+						theme: cancelPromptTheme,
+						sourceProduct: sourceProduct,
+						analyticsContext: analyticsContext
+					) {
+						onCompletion?(.purchased)
+					}
+				}
+				else {
+					onCompletion?(.dismissed)
+				}
+			}
+		}
+
+		return host
+	}
+
+
+	private static func findExpiringTrialEntitlement(
+		productIdentifiers: Set<String>,
+		within: TimeInterval
+	) async throws -> EntitlementInfo? {
+		let info = try await Purchases.shared.customerInfo()
+		return info.entitlements.active.values.first { entitlement in
+			guard entitlement.periodType == .trial else { return false }
+			guard productIdentifiers.contains(entitlement.productIdentifier) else { return false }
+			guard let expiration = entitlement.expirationDate else { return false }
+			let remaining = expiration.timeIntervalSinceNow
+			return remaining > 0 && remaining <= within
+		}
+	}
+}
+
+
+@MainActor
+private final class PurchaseSignal {
+	var didPurchase: Bool = false
+	var requestDismiss: (() -> Void)?
+}
+
+
+struct UpsellStorage {
+	let key: String
+
+	private var namespacedKey: String { "kovalee.subscriptionUpsell.\(key).shownAt" }
+
+	var hasShown: Bool {
+		UserDefaults.standard.object(forKey: namespacedKey) != nil
+	}
+
+	func markShown() {
+		UserDefaults.standard.set(Date(), forKey: namespacedKey)
+	}
+}
+#endif

--- a/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsellPresenter.swift
+++ b/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsellPresenter.swift
@@ -245,7 +245,7 @@ enum SubscriptionUpsellPresenter {
 			SubscriptionUpsellAnalytics.paywallClosed(in: analyticsContext, purchased: purchased)
 			host.dismiss(animated: true) {
 				if purchased {
-					LifetimeCancelYearlyView.launchAtTop(
+					UpsellPostPurchaseView.launchAtTop(
 						theme: cancelPromptTheme,
 						sourceProduct: sourceProduct,
 						analyticsContext: analyticsContext

--- a/Sources/KovaleeSDKUI/SubscriptionUpsell/UpsellPostPurchaseView.swift
+++ b/Sources/KovaleeSDKUI/SubscriptionUpsell/UpsellPostPurchaseView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 import StoreKit
 import UIKit
 
-struct LifetimeCancelYearlyView: View {
+struct UpsellPostPurchaseView: View {
 	@Environment(\.dismiss) private var dismiss
 	let theme: SubscriptionUpsell.Theme
 	let sourceProduct: Product?
@@ -172,9 +172,16 @@ struct LifetimeCancelYearlyView: View {
 		// then drives the auto-dismiss through `fireDismissOnce()`.
 		defer {
 			Task { @MainActor in
+				defer { isLoading = false }
 				guard let current = await fetchWillAutoRenew() else {
-					didCancelTrialRenewal = true
-					isLoading = false
+					// No renewal status to read. When there's no source product
+					// at all (forced / deep-link path) there's nothing to verify,
+					// so close once the user returns from the sheet. But if we
+					// *have* a product and the read failed, leave the prompt up —
+					// "unknown" must not be treated as "cancelled".
+					if sourceProduct == nil {
+						didCancelTrialRenewal = true
+					}
 					return
 				}
 				if initialWillAutoRenew == true, current == false {
@@ -183,7 +190,6 @@ struct LifetimeCancelYearlyView: View {
 					}
 					didCancelTrialRenewal = true
 				}
-				isLoading = false
 			}
 		}
 
@@ -239,7 +245,7 @@ struct LifetimeCancelYearlyView: View {
 }
 
 
-extension LifetimeCancelYearlyView {
+extension UpsellPostPurchaseView {
 
 	@MainActor
 	static func launchAtTop(
@@ -253,7 +259,7 @@ extension LifetimeCancelYearlyView {
 			return
 		}
 		let host = UIHostingController(
-			rootView: LifetimeCancelYearlyView(
+			rootView: UpsellPostPurchaseView(
 				theme: theme,
 				sourceProduct: sourceProduct,
 				analyticsContext: analyticsContext,

--- a/Sources/KovaleeSDKUI/Subviews/SubscriptionUpsellDebugView.swift
+++ b/Sources/KovaleeSDKUI/Subviews/SubscriptionUpsellDebugView.swift
@@ -1,0 +1,36 @@
+#if os(iOS)
+import SwiftUI
+
+@available(iOS 16.0, *)
+struct SubscriptionUpsellDebugView: View {
+
+	@AppStorage(SubscriptionUpsellOverride.forceTriggerKey) private var forceTrigger: Bool = false
+	@State private var showResetAlert: Bool = false
+
+	var body: some View {
+		Toggle("Force Trigger on Launch", isOn: $forceTrigger)
+
+		if forceTrigger {
+			Text("Paywall will present on next foreground regardless of subscription state — only if the user hasn't seen it yet. Tap Reset Shown State to re-arm.")
+				.font(.caption)
+				.foregroundColor(.secondary)
+		}
+
+		Button("Reset Shown State") {
+			SubscriptionUpsellOverride.clearAllShownStates()
+			showResetAlert = true
+		}
+		.buttonStyle(.bordered)
+		.alert("Subscription Upsell", isPresented: $showResetAlert) {
+			Button("OK", role: .cancel) {}
+		} message: {
+			Text("Cleared show-once flags. The next eligible foreground will trigger the flow.")
+		}
+
+		Button("Preview Congrats Screen") {
+			SubscriptionUpsell.presentCongratsScreen()
+		}
+		.buttonStyle(.bordered)
+	}
+}
+#endif


### PR DESCRIPTION
## Summary

Adds a turnkey flow for users on an expiring free trial:
- Detect the trial via RevenueCat entitlement (or trigger explicitly via deep link / `presentNow`).
- Present the RevenueCat-hosted upsell paywall for a configured offering.
- On purchase, show a themable "Lifetime unlocked" screen that opens Apple's *Manage Subscriptions* sheet so the user can turn off auto-renewal on the original subscription (Apple doesn't allow developer-side cancellation).

Hosts configure with `SubscriptionUpsell.Configuration` and receive a final `Outcome` callback (`.notTriggered` / `.dismissed` / `.purchased`).

### What's included
- **Public API**: `SubscriptionUpsell.checkAndPresentIfNeeded` (UIKit), `.presentNow` (forced), `.handleDeepLink` for `<scheme>://upsell` routing, `.presentCongratsScreen` (debug preview), and `View.checkSubscriptionUpsell(configuration:)` (SwiftUI).
- **Trigger types**: `.yearly`, `.monthly`, `.weekly`, `.anySubscription`, `.productIdentifiers(...)` resolved against RC offerings.
- **Theming**: `SubscriptionUpsell.Theme` covers colors, fonts, and SF Symbols for both the confirmation step and the cancel-prompt step; hosts can register `defaultCancelPromptTheme` at launch.
- **Debug panel**: new *Subscription Upsell* section in `DebugView` with Force Trigger, Reset Shown State, and Preview Congrats Screen. Gated to debug/TestFlight builds.
- **Analytics**: emits `subscription_upsell_paywall_shown`, `subscription_upsell_paywall_closed`, `subscription_upsell_purchased`, `subscription_upsell_confirmation_ok_tapped`, `subscription_upsell_manage_subs_opened`, `subscription_upsell_renewal_cancelled_detected`, `subscription_upsell_dismissed_later` — all carry a shared `source` (`auto` vs `forced`) and `offering_id` for funnel joins.
- **Localization**: default English `Localizable.strings` bundled with the `KovaleeSDKUI` target; additional locales drop in without code changes.

### Notes on the design
- Concurrency: separate `inFlight` / `inFlightForced` sets so a deep-link path is never blocked by an in-progress trial check. `markShown` + `subscription_upsell_paywall_shown` only fire on successful presentation, otherwise the host completion gets `.notTriggered` (no orphaned callbacks).
- Self-cycle in the paywall close path is broken with `[weak host, weak purchaseSignal]` captures.
- `task(id:)` is used instead of deprecated `onChange(of:perform:)` for scene-phase and confirmation-state observation.
- An unreadable renewal status is treated as "unknown", not "cancelled": auto-dismiss on a nil status only happens on the forced path (no source product to verify).

## Test plan
- [ ] SDK builds clean for iOS
- [ ] DebugView -> Force Trigger on Launch + foreground -> RC paywall appears
- [ ] Purchase on RC paywall -> "Lifetime unlocked" -> "One last step" -> Apple Manage Subscriptions sheet
- [ ] Toggling off auto-renewal in the ASM sheet auto-dismisses the cancel-prompt screen
- [ ] "I'll do it later" dismisses immediately and fires `subscription_upsell_dismissed_later` with `renewal_cancelled` reflecting the actual state
- [ ] Reset Shown State re-arms the flow
- [ ] Preview Congrats Screen renders with `defaultCancelPromptTheme`
- [ ] Deep link `<scheme>://upsell` opens the paywall
- [ ] Amplitude shows the funnel events with matching `source` + `offering_id` properties
