### PR TITLE
:sparkles: Show framework build commit in debug console

### DIFF
--- a/Sources/KovaleeSDKUI/DebugView.swift
+++ b/Sources/KovaleeSDKUI/DebugView.swift
@@ -58,7 +58,9 @@
                 List {
                     Text("SDK Version: \(SDK_VERSION)")
                         .allowsHitTesting(false)
-                    Text("Framework Built: \(KovaleeConstants.frameworkBuildDate)")
+                    Text("Framework: \(KovaleeBuildInfo.commit)")
+                        .allowsHitTesting(false)
+                    Text("Built: \(KovaleeBuildInfo.builtAt)")
                         .allowsHitTesting(false)
                     Toggle("Enable Debug Mode", isOn: $isDebugModeOn)
 


### PR DESCRIPTION
## Summary
- Replaces the `Framework Built: <date>` line in the debug console (derived from the framework bundle's file modification date) with the real build commit + timestamp from `KovaleeBuildInfo`
- Debug console now shows `Framework: <commit>` and `Built: <timestamp>`

## Why
The old `KovaleeConstants.frameworkBuildDate` reads the bundle's file mtime, which changes on checkout and doesn't reflect the actual build — it can't tell you which framework commit you're running. A recent release shipped a stale framework binary and nothing surfaced the mismatch. Reading `KovaleeBuildInfo.commit` (stamped at build time) lets a tester see the exact source commit of the framework in-app.

## Dependency
Requires the companion change in **Kovalee-internal** (cotyapps/Kovalee-iOS-Framework#147) which adds `KovaleeBuildInfo`, **and** the framework rebuilt from that and re-bundled into `Frameworks/`. This PR will not compile against the framework binary currently in the repo (which predates `KovaleeBuildInfo`). Merge order: rebuild framework first, then this.

## Test plan
- [ ] Rebuild framework from Kovalee-internal HEAD and bundle into `Frameworks/`
- [ ] Open the debug console; `Framework:` shows the short commit, `Built:` shows the UTC timestamp
- [ ] A framework built from a dirty tree shows `<commit>-dirty`