### PR TITLE
:sparkles: Track ab_test_assigned event when AB test version is set

### DIFF
--- a/Sources/KovaleeRemoteConfig/AbTestAnalytics.swift
+++ b/Sources/KovaleeRemoteConfig/AbTestAnalytics.swift
@@ -1,0 +1,32 @@
+import Foundation
+import KovaleeFramework
+import KovaleeSDK
+
+#if canImport(FirebaseRemoteConfig)
+    /// Reports the resolved AB test version to analytics as a tracking event.
+    ///
+    /// The AB test value can resolve through several entry points — remote fetch and
+    /// debug overrides via ``Kovalee/abTestValue()``, and manual assignment via
+    /// ``Kovalee/setAbTestValue(_:)``. Since ``Kovalee/abTestValue()`` may be called
+    /// many times per launch, this actor dedupes so the event is only sent when the
+    /// value actually changes (deduplication is in-memory, so the event fires at most
+    /// once per launch for a stable value).
+    actor AbTestAnalytics {
+        static let shared = AbTestAnalytics()
+
+        /// Name of the event sent when an AB test version is assigned.
+        static let eventName = "ab_test_assigned"
+
+        private var lastReportedValue: String?
+
+        func report(value: String) {
+            guard value != lastReportedValue else { return }
+            lastReportedValue = value
+
+            KLogger.debug("🧪 Reporting AB test assignment: \(value)")
+            Kovalee.sendEvent(
+                Event(name: Self.eventName, properties: [Kovalee.abTestKey: value])
+            )
+        }
+    }
+#endif

--- a/Sources/KovaleeRemoteConfig/KovaleeRemoteConfig.swift
+++ b/Sources/KovaleeRemoteConfig/KovaleeRemoteConfig.swift
@@ -84,6 +84,7 @@ import KovaleeSDK
                 return nil
             }
 
+            await AbTestAnalytics.shared.report(value: value)
             return value
         }
 
@@ -112,6 +113,7 @@ import KovaleeSDK
             let valueToSet = value
             Task { @Sendable in
                 Self.shared.kovaleeManager?.setAbTestValue(valueToSet)
+                await AbTestAnalytics.shared.report(value: valueToSet)
             }
         }
 


### PR DESCRIPTION
## Summary

Previously the resolved AB test version was logged via `KLogger` but never sent to analytics, so users were not segmentable by variant. This adds a tracking event whenever the AB test version is set.

## Changes

- **New `AbTestAnalytics` actor** (`Sources/KovaleeRemoteConfig/AbTestAnalytics.swift`): sends an `ab_test_assigned` event via `Kovalee.sendEvent(...)` with the variant under the `ab_test_version` property key (`Kovalee.abTestKey`). Dedupes in-memory so the event fires at most once per launch for a stable value, rather than on every `abTestValue()` call.
- **`KovaleeRemoteConfig.swift`**: reports from both entry points —
  - `abTestValue()` (remote fetch + debug override)
  - `setAbTestValue(_:)` (manual assignment)

Everything is gated under `#if canImport(FirebaseRemoteConfig)`, matching the rest of the AB test feature.

## Notes

- Event only — no user property is set.
- Event name `ab_test_assigned` is a default; can be renamed to fit the tagging plan.

## Test plan

- [x] `swift build --target KovaleeRemoteConfig` succeeds
- [ ] Confirm `ab_test_assigned` appears in Amplitude with the correct `ab_test_version` value after a fetch and after a manual `setAbTestValue`