### PR TITLE
:bug: Emit payment_* telemetry from SubscriptionUpsell paywall

### DIFF
--- a/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsellPresenter.swift
+++ b/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsellPresenter.swift
@@ -4,6 +4,7 @@ import UIKit
 import SwiftUI
 import StoreKit
 import KovaleeFramework
+import KovaleeSDK
 import RevenueCat
 import RevenueCatUI
 
@@ -166,6 +167,18 @@ enum SubscriptionUpsellPresenter {
 	}
 
 
+	private static let paymentSource = "subscription_upsell"
+
+	private static func durationOf(_ package: Package) -> KovaleeSDK.Duration {
+		switch package.storeProduct.subscriptionPeriod?.unit {
+			case .day?: return .day
+			case .week?: return .week
+			case .month?: return .month
+			default: return .year
+		}
+	}
+
+
 	private static func resolveProductIdentifiers(
 		for trigger: SubscriptionUpsell.Trigger,
 		in offerings: Offerings
@@ -210,9 +223,25 @@ enum SubscriptionUpsellPresenter {
 
 		let purchaseSignal = PurchaseSignal()
 		let view = PaywallView(offering: offering)
+			.onPurchaseStarted { package in
+				purchaseSignal.purchasedProductId = package.storeProduct.productIdentifier
+				purchaseSignal.purchasedDuration = durationOf(package)
+				Kovalee.startedPurchasing(subscriptionWithProductId: package.storeProduct.productIdentifier, fromSource: paymentSource)
+			}
 			.onPurchaseCompleted { _ in
 				purchaseSignal.didPurchase = true
+				if let productId = purchaseSignal.purchasedProductId {
+					Kovalee.succesfullyPurchased(subscriptionWithProductId: productId, andDuration: purchaseSignal.purchasedDuration ?? .year, fromSource: paymentSource)
+				}
 				SubscriptionUpsellAnalytics.purchased(in: analyticsContext)
+			}
+			.onPurchaseCancelled {
+				Kovalee.paymentCancelledForSubscription(fromSource: paymentSource)
+			}
+			.onPurchaseFailure { _ in
+				if let productId = purchaseSignal.purchasedProductId {
+					Kovalee.paymentFailed(forSubscriptionWithId: productId, fromSource: paymentSource)
+				}
 			}
 			.onRequestedDismissal {
 				purchaseSignal.requestDismiss?()
@@ -283,6 +312,8 @@ enum SubscriptionUpsellPresenter {
 private final class PurchaseSignal {
 	var didPurchase: Bool = false
 	var requestDismiss: (() -> Void)?
+	var purchasedProductId: String?
+	var purchasedDuration: KovaleeSDK.Duration?
 }
 
 


### PR DESCRIPTION
## Problem

In-app purchases completed through the trial-lifetime **SubscriptionUpsell** paywall never emit the `payment_finish` Amplitude event (nor `payment_start` / `payment_cancel` / `payment_failure`). The PepTalk funnel showed purchases happening at the end of the upsell with no corresponding payment-finish event.

## Root cause

The `payment_*` events are emitted **only** by the binary `kovaleeManager.purchase(package:fromSource:)`. The SubscriptionUpsell flow drives its purchase through RevenueCatUI's `PaywallView` (`.onPurchaseCompleted`), which calls `Purchases.shared.purchase(...)` directly and **bypasses** `kovaleeManager` entirely. `RevenueCatWrapperImpl.purchase` and the `PurchasesDelegate` do not emit payment telemetry, so the whole payment funnel was skipped for upsell purchases — only the SDK's own `subscription_upsell_purchased` event fired.

The regular paywall (`PlansViewController` in the app) is unaffected because it calls `Kovalee.purchase(package:)`.

## Fix

Bridge the `PaywallView` purchase callbacks in `SubscriptionUpsellPresenter.makePaywallController` to the public Kovalee telemetry API:

- `.onPurchaseStarted` → `Kovalee.startedPurchasing(...)` → `payment_start`
- `.onPurchaseCompleted` → `Kovalee.succesfullyPurchased(...)` → **`payment_finish`**
- `.onPurchaseCancelled` → `Kovalee.paymentCancelledForSubscription(...)` → `payment_cancel`
- `.onPurchaseFailure` → `Kovalee.paymentFailed(...)` → `payment_failure`

All tagged `fromSource: "subscription_upsell"` so they're distinguishable in the payment funnel. The purchased product id / duration are captured in `onPurchaseStarted` and reused at completion.

## Notes

- `Kovalee.succesfullyPurchased`'s `andDuration:` argument is ignored by the SDK wrapper, but it's still derived correctly from the package's subscription period (defaulting to `.year`).
- Builds clean: `xcodebuild -scheme KovaleeSDKUI -destination 'generic/platform=iOS Simulator'` → **BUILD SUCCEEDED**.
