### PR TITLE
:sparkles: Add Kovalee.fetchCurrentOffering(forPlacement:) for RevenueCat placements

### DIFF
--- a/Sources/KovaleePurchases/KovaleePurchases.swift
+++ b/Sources/KovaleePurchases/KovaleePurchases.swift
@@ -296,6 +296,67 @@ public extension Kovalee {
         }
     }
 
+    /// Fetch the current ``Offering`` for a RevenueCat targeting placement.
+    ///
+    /// Use this to serve different offerings at different points in your app
+    /// (e.g. `"first_paywall"` vs `"repeat_paywall"`) without hardcoding offering
+    /// identifiers. The placement targeting rules configured in the RevenueCat
+    /// dashboard are resolved server-side.
+    ///
+    /// Unlike ``fetchCurrentOffering()``, this does not apply the legacy
+    /// `ab_test_version` metadata selection — placements are the targeting
+    /// mechanism. RevenueCat returns the placement's fallback offering when the
+    /// placement is not explicitly configured, and `nil` when the placement
+    /// explicitly excludes the user.
+    ///
+    /// - Parameters:
+    ///    - placement: the RevenueCat placement identifier
+    /// - Returns: the placement-targeted offering, or `nil` if none applies
+    static func fetchCurrentOffering(forPlacement placement: String) async throws -> KOffering? {
+        guard shared.kovaleeManager != nil else {
+            throw PurchaseError.initializationProblem
+        }
+        guard Purchases.isConfigured else {
+            throw PurchaseError.rcNotYetInitialized
+        }
+
+        KLogger.debug("🛍️ Fetching current offering for placement \"\(placement)\"...")
+
+        let offerings = try await Purchases.shared.offerings()
+        guard let offering = offerings.currentOffering(forPlacement: placement) else {
+            KLogger.debug("🛍️ No offering available for placement \"\(placement)\"")
+            return nil
+        }
+
+        KLogger.debug("🛍️ Fetched offering \(offering.identifier) for placement \"\(placement)\"")
+        return KOffering(offering: offering)
+    }
+
+    /// Fetch the current ``Offering`` for a RevenueCat targeting placement.
+    ///
+    /// - Parameters:
+    ///    - placement: the RevenueCat placement identifier
+    ///    - completion: the placement-targeted offering, or `nil` if none applies
+    static func fetchCurrentOffering(
+        forPlacement placement: String,
+        withCompletion completion: @escaping @Sendable (Result<KOffering?, Error>) -> Void
+    ) {
+        let placementCopy = placement // Create local copy
+        Task { @Sendable in
+            do {
+                let result = try await Self.fetchCurrentOffering(forPlacement: placementCopy)
+                DispatchQueue.main.async {
+                    completion(Result.success(result))
+                }
+            } catch {
+                let capturedError = error // Capture error locally
+                DispatchQueue.main.async {
+                    completion(Result.failure(capturedError))
+                }
+            }
+        }
+    }
+
     /// Restore purchase previously made by current user
     ///
     /// - Parameters:


### PR DESCRIPTION
## Summary

Adds SDK support for fetching a RevenueCat offering by **targeting placement**, so apps can serve different offerings at different points (e.g. `first_paywall` vs `repeat_paywall`) without hardcoding offering identifiers.

```swift
let offering = try await Kovalee.fetchCurrentOffering(forPlacement: "your-placement-identifier")
```

Both async/await and completion-handler variants are added, mirroring the existing `fetchCurrentOffering` API.

## Implementation notes

- `KovaleeManager` and the `PurchaseManager` protocol live in the **binary** `KovaleeFramework.xcframework`, so the existing `fetchCurrentOffering()` routing can't be extended for placements. The new method instead calls RevenueCat directly from the source `KovaleePurchases` module (which already depends on RevenueCat and owns the `KOffering` wrapper).
- Calls `Purchases.shared.offerings().currentOffering(forPlacement:)` and wraps the result in `KOffering`.
- Deliberately **bypasses the legacy `ab_test_version` metadata selection** — placements are the targeting mechanism (distinct path, as agreed in the ticket).
- Guards on SDK initialization (`shared.kovaleeManager`) and `Purchases.isConfigured` (the latter prevents a `fatalError` from `Purchases.shared` when the purchases capability isn't enabled).
- Returns `nil` when RevenueCat returns no offering for the placement — no manual fallback; RevenueCat's own fallback/exclusion rules apply.

## Testing

- `swift build --target KovaleePurchases` passes.

Closes STU-3232.