### PR TITLE
:sparkles: Add activeLongerThan upsell condition for established subscribers

### DIFF
--- a/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsell.swift
+++ b/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsell.swift
@@ -8,8 +8,9 @@ import SwiftUI
 /// Host apps configure with the RevenueCat offering to present and the product
 /// identifiers that count as the source subscription. The SDK then:
 ///
-/// 1. Checks for an active trial entitlement matching the product identifiers
-///    that `trigger` resolves to, whose expiration is within `triggerWithin`.
+/// 1. Checks for an active entitlement matching the product identifiers that
+///    `trigger` resolves to and satisfying `condition` — either a trial expiring
+///    within a window, or a non-trial subscription active longer than an interval.
 /// 2. Verifies the flow hasn't been shown before (idempotent per `storageKey`).
 /// 3. Presents the RC-hosted paywall for `offeringId`.
 /// 4. On successful purchase, presents a screen that opens Apple's
@@ -45,6 +46,16 @@ public enum SubscriptionUpsell {
 		case productIdentifiers(Set<String>)
 	}
 
+	/// What makes a matching entitlement eligible to trigger the upsell.
+	public enum Condition: Sendable, Equatable {
+		/// An active trial entitlement whose expiration is within the given window.
+		case trialExpiring(within: TimeInterval)
+		/// An active, non-trial subscription first purchased more than the given
+		/// interval ago. Re-engages established subscribers — e.g. upselling a
+		/// long-time yearly subscriber to lifetime.
+		case activeLongerThan(TimeInterval)
+	}
+
 	public struct Configuration: Sendable {
 		/// RevenueCat offering identifier rendered as the upsell paywall.
 		public let offeringId: String
@@ -52,8 +63,14 @@ public enum SubscriptionUpsell {
 		/// Which source subscription(s) to watch for an expiring trial.
 		public let trigger: Trigger
 
-		/// Time window before trial expiration during which to trigger.
+		/// Time window before trial expiration during which to trigger. Used as the
+		/// default for the `.trialExpiring` condition when `condition` is omitted.
 		public let triggerWithin: TimeInterval
+
+		/// What makes a matching entitlement eligible to trigger the upsell.
+		/// Defaults to `.trialExpiring(within: triggerWithin)` for backward
+		/// compatibility with callers that only set `triggerWithin`.
+		public let condition: Condition
 
 		/// Namespace key used to remember "already shown" state. Reusing the
 		/// same key across runs / sessions guarantees the flow shows once per
@@ -84,6 +101,7 @@ public enum SubscriptionUpsell {
 			trigger: Trigger,
 			triggerWithin: TimeInterval = 48 * 3600,
 			storageKey: String,
+			condition: Condition? = nil,
 			debugForceTrigger: Bool = false,
 			showCloseButton: Bool = false,
 			cancelPromptTheme: Theme? = nil
@@ -92,6 +110,7 @@ public enum SubscriptionUpsell {
 			self.trigger = trigger
 			self.triggerWithin = triggerWithin
 			self.storageKey = storageKey
+			self.condition = condition ?? .trialExpiring(within: triggerWithin)
 			self.debugForceTrigger = debugForceTrigger
 			self.showCloseButton = showCloseButton
 			self.cancelPromptTheme = cancelPromptTheme

--- a/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsell.swift
+++ b/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsell.swift
@@ -60,7 +60,8 @@ public enum SubscriptionUpsell {
 		/// RevenueCat offering identifier rendered as the upsell paywall.
 		public let offeringId: String
 
-		/// Which source subscription(s) to watch for an expiring trial.
+		/// Which source subscription(s) to watch. Scopes which products count
+		/// toward `condition` (e.g. `.yearly` resolves to the annual products).
 		public let trigger: Trigger
 
 		/// Time window before trial expiration during which to trigger. Used as the

--- a/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsell.swift
+++ b/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsell.swift
@@ -3,7 +3,7 @@ import Foundation
 import UIKit
 import SwiftUI
 
-/// Drives a "trial-ending → upsell paywall → cancel-original-subscription" flow.
+/// Drives an "eligible subscription → upsell paywall → cancel-original-subscription" flow.
 ///
 /// Host apps configure with the RevenueCat offering to present and the product
 /// identifiers that count as the source subscription. The SDK then:
@@ -78,8 +78,8 @@ public enum SubscriptionUpsell {
 		/// install.
 		public let storageKey: String
 
-		/// Skip trial-detection and present the paywall as if a matching trial
-		/// were expiring. The show-once gate still applies — once presented for
+		/// Skip condition-detection and present the paywall as if a matching
+		/// entitlement were found. The show-once gate still applies — once presented for
 		/// this `storageKey` the flow won't run again until the flag is cleared
 		/// via `SubscriptionUpsellOverride.clearAllShownStates()`. For QA /
 		/// screenshots only — ship with `false`.
@@ -199,7 +199,7 @@ public enum SubscriptionUpsell {
 	}
 
 
-	/// Force-presents the upsell paywall right now, bypassing trial detection
+	/// Force-presents the upsell paywall right now, bypassing condition detection
 	/// and the show-once gate. For deep links (e.g. `peptalk://upsell`) and
 	/// marketing re-engagement.
 	@MainActor

--- a/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsellPresenter.swift
+++ b/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsellPresenter.swift
@@ -308,7 +308,7 @@ enum SubscriptionUpsellPresenter {
 				case .activeLongerThan(let interval):
 					guard entitlement.periodType != .trial else { return false }
 					guard let start = entitlement.originalPurchaseDate else { return false }
-					return -start.timeIntervalSinceNow > interval
+					return Date().timeIntervalSince(start) > interval
 			}
 		}
 	}

--- a/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsellPresenter.swift
+++ b/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsellPresenter.swift
@@ -59,9 +59,9 @@ enum SubscriptionUpsellPresenter {
 					matchedProductId = productIds.first
 				}
 				else {
-					guard let entitlement = try await findExpiringTrialEntitlement(
-						productIdentifiers: productIds,
-						within: configuration.triggerWithin
+					guard let entitlement = try await findEntitlement(
+						matching: configuration.condition,
+						productIdentifiers: productIds
 					) else {
 						onCompletion?(.notTriggered)
 						return
@@ -292,17 +292,24 @@ enum SubscriptionUpsellPresenter {
 	}
 
 
-	private static func findExpiringTrialEntitlement(
-		productIdentifiers: Set<String>,
-		within: TimeInterval
+	private static func findEntitlement(
+		matching condition: SubscriptionUpsell.Condition,
+		productIdentifiers: Set<String>
 	) async throws -> EntitlementInfo? {
 		let info = try await Purchases.shared.customerInfo()
 		return info.entitlements.active.values.first { entitlement in
-			guard entitlement.periodType == .trial else { return false }
 			guard productIdentifiers.contains(entitlement.productIdentifier) else { return false }
-			guard let expiration = entitlement.expirationDate else { return false }
-			let remaining = expiration.timeIntervalSinceNow
-			return remaining > 0 && remaining <= within
+			switch condition {
+				case .trialExpiring(let within):
+					guard entitlement.periodType == .trial else { return false }
+					guard let expiration = entitlement.expirationDate else { return false }
+					let remaining = expiration.timeIntervalSinceNow
+					return remaining > 0 && remaining <= within
+				case .activeLongerThan(let interval):
+					guard entitlement.periodType != .trial else { return false }
+					guard let start = entitlement.originalPurchaseDate else { return false }
+					return -start.timeIntervalSinceNow > interval
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Generalize `SubscriptionUpsell` trigger with a `Condition`

Adds a second way for `SubscriptionUpsell` to fire, alongside the existing "trial expiring soon" flow: **a non-trial subscription that has been active longer than an interval**. This lets host apps re-engage established subscribers (e.g. upsell a long-time yearly subscriber to lifetime) through the same RC-paywall + cancel-original-subscription + analytics machinery — no app-side entitlement inspection needed.

Motivated by Pep Talk **STU-3236** ("show `Default_2` to yearly subscribers active >14 days on reopen"), which currently reimplements this gating app-side via `presentNow`.

### API
```swift
public enum Condition: Sendable, Equatable {
    case trialExpiring(within: TimeInterval)   // existing behavior
    case activeLongerThan(TimeInterval)        // new
}
```
`Configuration.init` gains `condition: Condition? = nil`. When omitted it defaults to `.trialExpiring(within: triggerWithin)`, so **every existing caller is unchanged** (fully source-compatible).

### Behavior
- `run` now resolves a matching entitlement via a unified `findEntitlement(matching:productIdentifiers:)`:
  - `.trialExpiring(within:)` — active **trial** entitlement, expiring within the window (unchanged logic).
  - `.activeLongerThan(_:)` — active **non-trial** entitlement whose `originalPurchaseDate` is older than the interval (subscriber-since, stable across renewals).
- `trigger` still scopes which products count (`.yearly` → yearly product IDs via the existing `resolveProductIdentifiers`), so the SDK detects "yearly" natively.
- Show-once (`storageKey`), in-flight dedup, `presentNow`, and the post-purchase flow are untouched.

### Usage (host)
```swift
let cfg = SubscriptionUpsell.Configuration(
    offeringId: "Default_2",
    trigger: .yearly,
    storageKey: "yearly_lifetime_upsell",
    condition: .activeLongerThan(14 * 24 * 3600)
)
SubscriptionUpsell.checkAndPresentIfNeeded(configuration: cfg, from: vc)
```

### Testing
- `xcodebuild -scheme KovaleeSDKUI -destination 'generic/platform=iOS Simulator'`: **BUILD SUCCEEDED**, 0 errors/warnings.
- No behavior change for existing `.pep`-style configs (default condition reproduces the prior trial path).

### Follow-up
After release, Pep Talk PR Peptalk/peptalk-ios#46 drops its app-side gating (`Membership.hasActiveYearlySubscription`, the `yearlyUpsellShown` flag, the `presentNow` bypass) in favor of this `condition`.
