### PR TITLE
:sparkles: Honor ?offering= override in upsell deep link [STU-3237]

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,8 @@ func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>)
 }
 ```
 
+Add an `?offering=<id>` query item to target a specific paywall, overriding `configuration.offeringId` for that link only — e.g. `<scheme>://upsell?offering=Default_2` to email a harder-discount offering. Every other configuration field is preserved; without the param the configured offering is used.
+
 Or present directly:
 
 ```swift

--- a/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsell.swift
+++ b/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsell.swift
@@ -116,6 +116,21 @@ public enum SubscriptionUpsell {
 			self.showCloseButton = showCloseButton
 			self.cancelPromptTheme = cancelPromptTheme
 		}
+
+		/// Copy with a different RevenueCat offering, keeping every other field.
+		/// Used by `handleDeepLink` to honor an `?offering=` override.
+		public func overridingOffering(id: String) -> Configuration {
+			Configuration(
+				offeringId: id,
+				trigger: trigger,
+				triggerWithin: triggerWithin,
+				storageKey: storageKey,
+				condition: condition,
+				debugForceTrigger: debugForceTrigger,
+				showCloseButton: showCloseButton,
+				cancelPromptTheme: cancelPromptTheme
+			)
+		}
 	}
 
 	public enum Outcome: Sendable, Equatable {
@@ -243,6 +258,11 @@ public enum SubscriptionUpsell {
 	/// - `<scheme>://upsell/`
 	/// - `<scheme>:///upsell` (hostless variant — path-only)
 	///
+	/// An optional `?offering=<id>` query item overrides
+	/// `configuration.offeringId`, so a single deep link can target any paywall
+	/// (e.g. `<scheme>://upsell?offering=Default_2` for a harder-discount
+	/// offering sent by email). Every other configuration field is preserved.
+	///
 	/// ### What does NOT match
 	/// - `<scheme>://app/upsell` — `upsell` must be the host (or be the entire
 	///   path in the hostless variant), not nested under another host.
@@ -265,8 +285,19 @@ public enum SubscriptionUpsell {
 		let hostIsUpsell = url.host == "upsell" && (url.path.isEmpty || url.path == "/")
 		let hostlessUpsellPath = (url.host?.isEmpty ?? true) && url.path == "/upsell"
 		guard hostIsUpsell || hostlessUpsellPath else { return false }
-		presentNow(configuration: configuration, from: presenter, onCompletion: onCompletion)
+		let resolved = offeringOverride(in: url).map(configuration.overridingOffering) ?? configuration
+		presentNow(configuration: resolved, from: presenter, onCompletion: onCompletion)
 		return true
+	}
+
+
+	/// Reads `?offering=<id>` from a deep link, trimming whitespace and the
+	/// surrounding quotes that hand-authored marketing links sometimes carry.
+	private static func offeringOverride(in url: URL) -> String? {
+		guard let items = URLComponents(url: url, resolvingAgainstBaseURL: false)?.queryItems else { return nil }
+		guard let raw = items.first(where: { $0.name == "offering" })?.value else { return nil }
+		let trimmed = raw.trimmingCharacters(in: CharacterSet(charactersIn: "\"").union(.whitespacesAndNewlines))
+		return trimmed.isEmpty ? nil : trimmed
 	}
 }
 #endif


### PR DESCRIPTION
## What

Adds an optional `?offering=<id>` query item to the upsell deep link so a single link can target any RevenueCat offering (e.g. a harder-discount paywall sent by email).

`peptalk://upsell?offering=Default_2` now presents the `Default_2` offering instead of the host app's configured default.

Closes STU-3237.

## How

- `SubscriptionUpsell.handleDeepLink` reads `?offering=` (via `URLComponents`, trimming whitespace and stray surrounding quotes) and, when present, overrides `configuration.offeringId`. Absent the param, behavior is unchanged.
- New `Configuration.overridingOffering(id:)` copies the config swapping only the offering, preserving every other field.
- URL matching is untouched — the existing host/path guards already ignored the query string, so `://upsell?offering=…` already matched.
- Analytics report the resolved (overridden) offering, since the override is applied before `runForced` builds its context.

## Host app

No change required: peptalk-ios already delegates its deep-link fallback to `SubscriptionUpsell.handleDeepLink(url, configuration: .pep, …)`. After this ships in a release and the app bumps the SDK version, the new param works as-is.

## Verification

- `KovaleeSDKUI` builds for the iOS simulator (`** BUILD SUCCEEDED **`).
- peptalk-ios builds, runs, and routes the deep link without crashing against a local checkout of this branch (workspace override). End-to-end paywall render is gated by the app's pre-existing `Credentials.isLoggedIn` + RC `Default_2` config, neither touched here.