### PR TITLE
Add Firebase Advanced Consent Mode support (setAdvertisingConsentGranted)

### DIFF
--- a/Sources/KovaleeRemoteConfig/FirebaseWrapperImpl.swift
+++ b/Sources/KovaleeRemoteConfig/FirebaseWrapperImpl.swift
@@ -52,6 +52,21 @@ actor FirebaseWrapperImpl: RemoteConfigurationManager, Manager {
         #endif
     }
 
+    /// Firebase Advanced Consent Mode: updates the advertising consent types once the ATT
+    /// decision is known. Analytics collection stays on (so ODM keeps capturing de-identified
+    /// signals at launch); only the ad-related consents move. `analytics_storage` is left at the
+    /// app's Info.plist default (GOOGLE_ANALYTICS_DEFAULT_ALLOW_ANALYTICS_STORAGE).
+    nonisolated func setAdvertisingConsentGranted(_ granted: Bool) {
+        #if canImport(FirebaseAnalytics)
+            let status: ConsentStatus = granted ? .granted : .denied
+            Analytics.setConsent([
+                .adStorage: status,
+                .adUserData: status,
+                .adPersonalization: status,
+            ])
+        #endif
+    }
+
     nonisolated func setDefaultValues(_ values: [String: Any]) {
         #if canImport(FirebaseRemoteConfig)
             RemoteConfig.remoteConfig().setDefaults(values as? [String: NSObject])


### PR DESCRIPTION
## What

Companion to **cotyapps/Kovalee-iOS-Framework#150** (Advanced Consent Mode). Implements the open-source side of the new `RemoteConfigurationManager.setAdvertisingConsentGranted(_:)` method.

`FirebaseWrapperImpl.setAdvertisingConsentGranted(_:)` → `Analytics.setConsent` for the advertising consent types:

```swift
Analytics.setConsent([
  .adStorage: status, .adUserData: status, .adPersonalization: status,
])
```

The binary calls this from the ATT-completion hook: granted on `.authorized`, denied otherwise. Analytics collection is never disabled, so `first_open` / ODM run from launch; `analytics_storage` stays at the app's Info.plist default.

## Dependency / release order

- Requires the binary change in **#150** (which declares the protocol method) — this PR is the conformer. It compiles standalone today (extra method), and is fully wired once the rebuilt `KovaleeFramework.xcframework` ships.
- Release flow: merge #150 → `make build-framework` → updated `KovaleeFramework.xcframework.zip` lands here → tag a new SDK release.

## Validation

Sim-tested with 75hard against a locally-built consent binary: ad consent denied at launch, `🔓 granted` on ATT Allow, `🔒 denied` on ATT Deny; `first_open` fires at launch.
