### PR TITLE
:recycle: Unify feedback & upsell styling into KovaleeUIStyle

### DIFF
--- a/Documentation/FEEDBACK.md
+++ b/Documentation/FEEDBACK.md
@@ -44,7 +44,7 @@ All feedback content and settings are configured once through `KovaleeUI.configu
 ```swift
 KovaleeUI.configuration.appIcon         = Image("AppIcon")
 KovaleeUI.configuration.feedbackChoices  = ["Daily journal", "Streaks", "Community challenges", "Other"]
-KovaleeUI.configuration.feedbackStyle    = .myAppStyle      // shared by both flows (see Styling)
+KovaleeUI.configuration.style            = .myAppStyle      // shared by feedback + upsell (see Styling)
 
 KovaleeUI.configuration.founderFeedbackText = FeedbackText(
     cta: "Send feedback",
@@ -109,7 +109,7 @@ Present the view directly, constructing the configuration from `KovaleeUI.config
     Task {
         let configuration = UserFeedbackConfiguration(
             feedbackText: KovaleeUI.configuration.founderFeedbackText,
-            feedbackStyle: KovaleeUI.configuration.feedbackStyle,
+            feedbackStyle: KovaleeUI.configuration.style,
             feedbackMetadata: await .fromKovalee()
         )
         present(
@@ -157,7 +157,7 @@ Present `FeedbackFormView` directly. `featureFeedbackText` is optional on the co
 Task {
     guard let text = KovaleeUI.configuration.featureFeedbackText else { return }
     let config = FeatureFeedbackConfiguration(
-        style: KovaleeUI.configuration.feedbackStyle,
+        style: KovaleeUI.configuration.style,
         text: text,
         appIcon: KovaleeUI.configuration.appIcon,
         choices: KovaleeUI.configuration.feedbackChoices,
@@ -192,11 +192,11 @@ Task {
 
 ## Styling
 
-Both flows share a single `FeedbackStyle`. All fields are defaulted, so `.default` works out of the box. Set it once via `KovaleeUI.configuration.feedbackStyle`:
+The feedback sheets and the subscription-upsell post-purchase screens share a single `KovaleeUIStyle`. All fields are defaulted, so `.default` works out of the box. Set it once via `KovaleeUI.configuration.style`. The fields below drive the feedback sheets; `KovaleeUIStyle` also carries upsell-only `titleFont`/`bodyFont`/`buttonFont` and `confirmationIcon`/`cancelPromptIcon` (see the upsell docs):
 
 ```swift
-extension FeedbackStyle {
-    static let myAppStyle = FeedbackStyle(
+extension KovaleeUIStyle {
+    static let myAppStyle = KovaleeUIStyle(
         backgroundColor: Color("background"),
         primaryColor: .white,                      // titles
         secondaryColor: .white.opacity(0.8),       // subtitle / body / notes text

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The host app never sees subscription state, paywall internals, or the manage-sub
        triggerWithin: 48 * 3600,                // …expiring within 48h (default: 48h, optional)
        storageKey: "trial_to_lifetime_v1",      // namespace for the show-once flag
        showCloseButton: false,                  // overlay an X if your paywall has no dismiss UI (default: false)
-       cancelPromptTheme: nil                   // use the default congrats-screen theme (default: nil)
+       cancelPromptStyle: nil                   // per-flow override; nil = shared KovaleeUI.configuration.style (default: nil)
    )
    ```
 
@@ -222,21 +222,22 @@ Or present directly:
 SubscriptionUpsell.presentNow(configuration: upsellConfig, from: presenter)
 ```
 
-### Theming the congrats screen
+### Styling the congrats screen
 
-The post-purchase "Lifetime unlocked" screen is themable. Register a global default at launch so QA and debug previews match production:
+The post-purchase "Lifetime unlocked" / cancel-prompt screens derive their look from the shared `KovaleeUI.configuration.style` — the same `KovaleeUIStyle` the feedback sheets use — so they match your app out of the box. On top of the shared colors, `KovaleeUIStyle` carries upsell-only fonts and the two hero SF Symbols:
 
 ```swift
-SubscriptionUpsell.defaultCancelPromptTheme = SubscriptionUpsell.Theme(
-    background: .black,
-    iconTint: .yellow,
-    primaryButtonBackground: .yellow,
-    primaryButtonForeground: .black,
-    iconSystemName: "crown.fill"
+KovaleeUI.configuration.style = KovaleeUIStyle(
+    backgroundColor: .black,
+    primaryColor: .white,                    // title
+    secondaryColor: .white.opacity(0.8),     // body
+    ctaColor: .yellow,                        // hero icon + primary button
+    confirmationIcon: "crown.fill",           // "Lifetime unlocked" hero icon
+    cancelPromptIcon: "bell.slash.fill"       // "One last step" hero icon
 )
 ```
 
-Per-call overrides take precedence via `Configuration.cancelPromptTheme`.
+The primary button's text color is derived automatically for contrast against `ctaColor`. Per-flow overrides take precedence via `Configuration.cancelPromptStyle`.
 
 ### Debug / QA
 
@@ -274,7 +275,7 @@ All feedback content, styling, and choices are configured **once** through `Kova
 ```swift
 KovaleeUI.configuration.appIcon         = Image("AppIcon")
 KovaleeUI.configuration.feedbackChoices = ["Daily journal", "Streaks", "Community challenges", "Other"]
-KovaleeUI.configuration.feedbackStyle   = .myAppStyle      // shared by both flows
+KovaleeUI.configuration.style           = .myAppStyle      // shared by feedback + upsell
 
 KovaleeUI.configuration.founderFeedbackText = FeedbackText(
     cta: "Send feedback",
@@ -325,11 +326,11 @@ struct HomeView: View {
 
 ### Styling
 
-Both flows share a single `FeedbackStyle`. All fields are defaulted, so `.default` works out of the box — set `KovaleeUI.configuration.feedbackStyle` to theme them:
+The feedback sheets and the subscription-upsell post-purchase screens share a single `KovaleeUIStyle`. All fields are defaulted, so `.default` works out of the box — set `KovaleeUI.configuration.style` to theme them:
 
 ```swift
-extension FeedbackStyle {
-    static let myAppStyle = FeedbackStyle(
+extension KovaleeUIStyle {
+    static let myAppStyle = KovaleeUIStyle(
         backgroundColor: Color("background"),
         primaryColor: .white,                      // titles
         secondaryColor: .white.opacity(0.8),       // subtitle / body text

--- a/Sources/KovaleeSDKUI/Deprecations.swift
+++ b/Sources/KovaleeSDKUI/Deprecations.swift
@@ -1,0 +1,132 @@
+#if os(iOS)
+import Foundation
+import SwiftUI
+
+// Migration shims for the `KovaleeUIStyle` unification (feedback + subscription
+// upsell now share one style type, configured via `KovaleeUI.configuration.style`).
+// Keep partner code compiling for one release; remove in the next major.
+
+// MARK: Feedback styling — pure renames
+
+@available(*, unavailable, renamed: "KovaleeUIStyle")
+public typealias FeedbackStyle = KovaleeUIStyle
+
+@available(iOS 17, *)
+public extension KovaleeUI.Configuration {
+	@available(*, unavailable, renamed: "style")
+	var feedbackStyle: KovaleeUIStyle {
+		get { style }
+		set { style = newValue }
+	}
+}
+
+// MARK: Subscription upsell — `Theme` was replaced by `KovaleeUIStyle`
+//
+// `Theme` keeps working as an alias, and the old field-labelled initializer (in
+// the `KovaleeUIStyle` extension below) keeps existing call sites compiling with
+// a deprecation *warning* rather than a hard "extra arguments" error. Call sites
+// should still migrate by hand to the `KovaleeUIStyle` field names
+// (`background`→`backgroundColor`, `titleColor`→`primaryColor`,
+// `primaryButtonBackground`→`ctaColor`, `iconSystemName`→`confirmationIcon`, …);
+// remove the shim in the next major.
+
+public extension SubscriptionUpsell {
+
+	@available(*, deprecated, renamed: "KovaleeUIStyle")
+	typealias Theme = KovaleeUIStyle
+
+	@available(*, deprecated, renamed: "KovaleeUI.configuration.style")
+	@MainActor
+	static var defaultCancelPromptTheme: KovaleeUIStyle {
+		get { defaultCancelPromptStyle }
+		set {
+			if #available(iOS 17, *) {
+				KovaleeUI.configuration.style = newValue
+			}
+		}
+	}
+
+	@available(*, deprecated, renamed: "presentCongratsScreen(style:onCompletion:)")
+	@MainActor
+	static func presentCongratsScreen(
+		theme: KovaleeUIStyle?,
+		onCompletion: (@MainActor @Sendable () -> Void)? = nil
+	) {
+		presentCongratsScreen(style: theme, onCompletion: onCompletion)
+	}
+}
+
+// The old `SubscriptionUpsell.Theme` initializer, surfaced against the unified
+// `KovaleeUIStyle`. Marked `unavailable` (a hard *error*, not a warning) rather
+// than `deprecated`: the field shapes changed — three of the old per-element
+// colors were collapsed — so there is no automatic fix-it and a silent warning
+// could ship a miscolored upsell. The error carries the exact migration:
+//   • `iconTint`                → folded into `ctaColor` (the icon now uses the CTA accent)
+//   • `primaryButtonForeground` → derived by the SDK from `ctaColor`'s luminance
+//   • `secondaryButtonColor`    → folded into `secondaryColor`
+//
+// The init still exists (with a forwarding body) so the diagnostic is the clean
+// message below instead of a cryptic "extra arguments at positions …" error.
+// `@_disfavoredOverload` keeps the no-argument `KovaleeUIStyle()` resolving to the
+// real initializer (so `KovaleeUIStyle.default` and the new field-labelled call
+// sites stay unambiguous) — only the old labels below select this shim.
+public extension KovaleeUIStyle {
+	@_disfavoredOverload
+	@available(*, unavailable, message: "SubscriptionUpsell.Theme was unified into KovaleeUIStyle. Rename fields: background→backgroundColor, titleColor→primaryColor, bodyColor→secondaryColor, primaryButtonBackground→ctaColor, iconSystemName→confirmationIcon, cancelPromptIconSystemName→cancelPromptIcon. iconTint, primaryButtonForeground and secondaryButtonColor no longer exist (the icon and CTA share ctaColor; the CTA label color is derived automatically; the secondary button uses secondaryColor).")
+	init(
+		background: Color = Color(.systemBackground),
+		iconTint: Color = .accentColor,
+		titleColor: Color = .primary,
+		bodyColor: Color = .secondary,
+		primaryButtonBackground: Color = .accentColor,
+		primaryButtonForeground: Color = .white,
+		secondaryButtonColor: Color = .secondary,
+		titleFont: Font = .system(size: 32, weight: .semibold),
+		bodyFont: Font = .body,
+		buttonFont: Font = .headline,
+		iconSystemName: String = "checkmark.seal.fill",
+		cancelPromptIconSystemName: String = "exclamationmark.circle.fill"
+	) {
+		self.init(
+			backgroundColor: background,
+			primaryColor: titleColor,
+			secondaryColor: bodyColor,
+			ctaColor: primaryButtonBackground,
+			titleFont: titleFont,
+			bodyFont: bodyFont,
+			buttonFont: buttonFont,
+			confirmationIcon: iconSystemName,
+			cancelPromptIcon: cancelPromptIconSystemName
+		)
+	}
+}
+
+public extension SubscriptionUpsell.Configuration {
+
+	@available(*, deprecated, renamed: "cancelPromptStyle")
+	var cancelPromptTheme: KovaleeUIStyle? { cancelPromptStyle }
+
+	@available(*, deprecated, renamed: "init(offeringId:trigger:triggerWithin:storageKey:condition:debugForceTrigger:showCloseButton:cancelPromptStyle:)")
+	init(
+		offeringId: String,
+		trigger: SubscriptionUpsell.Trigger,
+		triggerWithin: TimeInterval = 48 * 3600,
+		storageKey: String,
+		condition: SubscriptionUpsell.Condition? = nil,
+		debugForceTrigger: Bool = false,
+		showCloseButton: Bool = false,
+		cancelPromptTheme: KovaleeUIStyle?
+	) {
+		self.init(
+			offeringId: offeringId,
+			trigger: trigger,
+			triggerWithin: triggerWithin,
+			storageKey: storageKey,
+			condition: condition,
+			debugForceTrigger: debugForceTrigger,
+			showCloseButton: showCloseButton,
+			cancelPromptStyle: cancelPromptTheme
+		)
+	}
+}
+#endif

--- a/Sources/KovaleeSDKUI/Feedback/Coordinator/FeatureFeedbackConfiguration.swift
+++ b/Sources/KovaleeSDKUI/Feedback/Coordinator/FeatureFeedbackConfiguration.swift
@@ -32,7 +32,7 @@ public struct FeatureFeedbackText: Sendable {
 
 @available(iOS 17, *)
 public struct FeatureFeedbackConfiguration: Sendable {
-    public var style: FeedbackStyle
+    public var style: KovaleeUIStyle
     public var text: FeatureFeedbackText
     public var appIcon: Image
     public var choices: [String]
@@ -41,7 +41,7 @@ public struct FeatureFeedbackConfiguration: Sendable {
     public var onNotesActionTapped: (@Sendable () -> Void)?
 
     public init(
-        style: FeedbackStyle = .default,
+        style: KovaleeUIStyle = .default,
         text: FeatureFeedbackText,
         appIcon: Image,
         choices: [String],

--- a/Sources/KovaleeSDKUI/Feedback/Coordinator/FeedbackCoordinator+Kovalee.swift
+++ b/Sources/KovaleeSDKUI/Feedback/Coordinator/FeedbackCoordinator+Kovalee.swift
@@ -27,7 +27,7 @@ public extension FeedbackCoordinator {
             showFounder(
                 UserFeedbackConfiguration(
                     feedbackText: KovaleeUI.configuration.founderFeedbackText,
-                    feedbackStyle: KovaleeUI.configuration.feedbackStyle,
+                    feedbackStyle: KovaleeUI.configuration.style,
                     feedbackMetadata: metadata
                 ),
                 showBackButton: showBackButton
@@ -60,7 +60,7 @@ public extension FeedbackCoordinator {
             }
             showFeatures(
                 FeatureFeedbackConfiguration(
-                    style: KovaleeUI.configuration.feedbackStyle,
+                    style: KovaleeUI.configuration.style,
                     text: featureFeedbackText,
                     appIcon: KovaleeUI.configuration.appIcon,
                     choices: KovaleeUI.configuration.feedbackChoices,

--- a/Sources/KovaleeSDKUI/Feedback/Feedback/DataModel/UserFeedbackConfiguration.swift
+++ b/Sources/KovaleeSDKUI/Feedback/Feedback/DataModel/UserFeedbackConfiguration.swift
@@ -4,7 +4,7 @@ import SwiftUI
 @available(iOS 17, *)
 public struct UserFeedbackConfiguration: Sendable {
     public let feedbackText: FeedbackText
-    public let feedbackStyle: FeedbackStyle
+    public let feedbackStyle: KovaleeUIStyle
     public let feedbackMetadata: FeedbackMetadata
     public let secondaryButton: SecondaryButton?
 
@@ -20,7 +20,7 @@ public struct UserFeedbackConfiguration: Sendable {
 
     public init(
         feedbackText: FeedbackText,
-        feedbackStyle: FeedbackStyle = .default,
+        feedbackStyle: KovaleeUIStyle = .default,
         feedbackMetadata: FeedbackMetadata,
         secondaryButton: SecondaryButton? = nil
     ) {
@@ -55,42 +55,74 @@ public struct FeedbackText: Sendable {
 	}
 }
 
-@available(iOS 17, *)
-public struct FeedbackStyle: Sendable {
+/// Shared visual styling for the feedback sheets **and** the subscription-upsell
+/// post-purchase screens. Partners configure it once via
+/// ``KovaleeUI/Configuration/style`` and both surfaces honor it.
+///
+/// The color fields drive every surface; the `title`/`body`/`button` fonts and
+/// the two `…Icon` SF Symbols are only consumed by the upsell post-purchase
+/// screens (the feedback sheets use their own fixed typography). All fields are
+/// defaulted, so a host can present without configuring anything.
+public struct KovaleeUIStyle: Sendable {
+    // Colors shared by the feedback sheets and the upsell post-purchase screens,
+    // ordered to mirror the legacy `SubscriptionUpsell.Theme`
+    // (`background`/`titleColor`/`bodyColor`/`primaryButtonBackground`) so the
+    // migration is a rename-in-place.
     public var backgroundColor: Color
     public var primaryColor: Color
     public var secondaryColor: Color
-    public var secondaryBackgroundColor: Color
     public var ctaColor: Color
+    // Feedback-sheet-only colors.
+    public var secondaryBackgroundColor: Color
     public var selectedColor: Color
     public var unselectedColor: Color
     public var buttonCornerRadius: CGFloat
     public var symbol: String?
+    // Upsell post-purchase screens only.
+    public var titleFont: Font
+    public var bodyFont: Font
+    public var buttonFont: Font
+    /// SF Symbol shown above the "Lifetime unlocked" confirmation step.
+    public var confirmationIcon: String
+    /// SF Symbol shown above the "One last step" cancel-prompt step. Kept
+    /// separate from `confirmationIcon` so the celebratory icon doesn't carry
+    /// over into the more cautionary "turn off auto-renewal" screen.
+    public var cancelPromptIcon: String
 
     public init(
         backgroundColor: Color = Color(.systemBackground),
         primaryColor: Color = .primary,
         secondaryColor: Color = .secondary,
-        secondaryBackgroundColor: Color = Color(.secondarySystemBackground),
         ctaColor: Color = .accentColor,
+        secondaryBackgroundColor: Color = Color(.secondarySystemBackground),
         selectedColor: Color = .primary,
         unselectedColor: Color = .primary,
         buttonCornerRadius: CGFloat = 16,
-        symbol: String? = nil
+        symbol: String? = nil,
+        titleFont: Font = .system(size: 32, weight: .semibold),
+        bodyFont: Font = .body,
+        buttonFont: Font = .headline,
+        confirmationIcon: String = "checkmark.seal.fill",
+        cancelPromptIcon: String = "exclamationmark.circle.fill"
     ) {
         self.backgroundColor = backgroundColor
         self.primaryColor = primaryColor
         self.secondaryColor = secondaryColor
-        self.secondaryBackgroundColor = secondaryBackgroundColor
         self.ctaColor = ctaColor
+        self.secondaryBackgroundColor = secondaryBackgroundColor
         self.selectedColor = selectedColor
         self.unselectedColor = unselectedColor
         self.buttonCornerRadius = buttonCornerRadius
         self.symbol = symbol
+        self.titleFont = titleFont
+        self.bodyFont = bodyFont
+        self.buttonFont = buttonFont
+        self.confirmationIcon = confirmationIcon
+        self.cancelPromptIcon = cancelPromptIcon
     }
 
     /// Sensible out-of-the-box styling, so a host can present without configuring colors.
-    public static let `default` = FeedbackStyle()
+    public static let `default` = KovaleeUIStyle()
 }
 
 @available(iOS 17, *)
@@ -135,12 +167,12 @@ extension UserFeedbackConfiguration {
 			imageName: "feedback-image",
 			successText: "Feedback received!"
 		),
-		feedbackStyle: FeedbackStyle(
+		feedbackStyle: KovaleeUIStyle(
 			backgroundColor: .black,
 			primaryColor: .white,
 			secondaryColor: .white,
-			secondaryBackgroundColor: Color(UIColor.darkGray),
-			ctaColor: .red
+			ctaColor: .red,
+			secondaryBackgroundColor: Color(UIColor.darkGray)
 		),
 		feedbackMetadata: FeedbackMetadata(
 			appVersion: "1.0.0",

--- a/Sources/KovaleeSDKUI/Feedback/Feedback/Subviews/ActionButton.swift
+++ b/Sources/KovaleeSDKUI/Feedback/Feedback/Subviews/ActionButton.swift
@@ -5,7 +5,7 @@ import UIKit
 @available(iOS 17, *)
 struct ActionButton: View {
 	let text: String
-	let style: FeedbackStyle
+	let style: KovaleeUIStyle
 	let isDisabled: Bool
 	let onSubmitAction: () -> Void
     let symbol: String?
@@ -15,7 +15,7 @@ struct ActionButton: View {
 		return backgroundColor.isLight ? .black : .white
 	}
 
-    init(text: String, symbol: String? = nil, style: FeedbackStyle, isDisabled: Bool, onSubmitAction: @escaping () -> Void) {
+    init(text: String, symbol: String? = nil, style: KovaleeUIStyle, isDisabled: Bool, onSubmitAction: @escaping () -> Void) {
         self.text = text
         self.style = style
         self.isDisabled = isDisabled
@@ -46,7 +46,6 @@ struct ActionButton: View {
 	}
 }
 
-@available(iOS 17, *)
 extension Color {
 	var isLight: Bool {
 		let uiColor = UIColor(self).resolvedColor(with: UITraitCollection.current)

--- a/Sources/KovaleeSDKUI/Feedback/Feedback/Subviews/CountryPicker.swift
+++ b/Sources/KovaleeSDKUI/Feedback/Feedback/Subviews/CountryPicker.swift
@@ -4,7 +4,7 @@ import SwiftUI
 @available(iOS 17, *)
 struct CountryPicker: View {
 	@Binding var selectedCountryCode: String
-	let style: FeedbackStyle
+	let style: KovaleeUIStyle
     let countries: [Country] = Country.supportedCountries
 
 	private var selectedCountry: Country? {

--- a/Sources/KovaleeSDKUI/Feedback/Feedback/Subviews/CustomTextEditor.swift
+++ b/Sources/KovaleeSDKUI/Feedback/Feedback/Subviews/CustomTextEditor.swift
@@ -8,7 +8,7 @@ struct CustomTextEditor<FocusValue: Hashable>: View {
 	var focusValue: FocusValue?
 
 	let placeholder: String
-	let style: FeedbackStyle
+	let style: KovaleeUIStyle
 	let minHeight: CGFloat
 	
 	var body: some View {

--- a/Sources/KovaleeSDKUI/Feedback/Feedback/Subviews/CustomTextField.swift
+++ b/Sources/KovaleeSDKUI/Feedback/Feedback/Subviews/CustomTextField.swift
@@ -8,7 +8,7 @@ struct CustomTextField<FocusValue: Hashable>: View {
 	var focusValue: FocusValue?
 
 	let placeholder: String
-	let style: FeedbackStyle
+	let style: KovaleeUIStyle
 	let keyboardType: UIKeyboardType
 	let autocapitalization: UITextAutocapitalizationType
 	

--- a/Sources/KovaleeSDKUI/Feedback/Feedback/Subviews/FormField.swift
+++ b/Sources/KovaleeSDKUI/Feedback/Feedback/Subviews/FormField.swift
@@ -4,7 +4,7 @@ import SwiftUI
 @available(iOS 17, *)
 struct FormField<Content: View>: View {
 	let title: String
-	let style: FeedbackStyle
+	let style: KovaleeUIStyle
 
 	@ViewBuilder let content: () -> Content
 	

--- a/Sources/KovaleeSDKUI/Feedback/Feedback/UserFeedbackFormView.swift
+++ b/Sources/KovaleeSDKUI/Feedback/Feedback/UserFeedbackFormView.swift
@@ -31,7 +31,7 @@ public struct UserFeedbackFormView: View {
 	public let configuration: UserFeedbackConfiguration
 	private let onCompletion: (() -> Void)?
 	
-	private var style: FeedbackStyle {
+	private var style: KovaleeUIStyle {
 		configuration.feedbackStyle
 	}
 	
@@ -198,7 +198,7 @@ extension UserFeedbackFormView {
 
 @available(iOS 17, *)
 private struct LoadingOverlay: View {
-	let style: FeedbackStyle
+	let style: KovaleeUIStyle
 	
 	var body: some View {
 		ZStack {

--- a/Sources/KovaleeSDKUI/Feedback/Feedback/UserFeedbackView.swift
+++ b/Sources/KovaleeSDKUI/Feedback/Feedback/UserFeedbackView.swift
@@ -8,7 +8,7 @@ public struct UserFeedbackView: View {
 
     public let configuration: UserFeedbackConfiguration
     public let showBackButton: Bool
-    private var style: FeedbackStyle {
+    private var style: KovaleeUIStyle {
         configuration.feedbackStyle
     }
 

--- a/Sources/KovaleeSDKUI/KovaleeUI.swift
+++ b/Sources/KovaleeSDKUI/KovaleeUI.swift
@@ -7,6 +7,7 @@ import SwiftUI
 /// ```swift
 /// KovaleeUI.configuration.appIcon        = Image("AppIcon")
 /// KovaleeUI.configuration.feedbackChoices = ["Performance", "Design", "Notifications"]
+/// KovaleeUI.configuration.style           = KovaleeUIStyle(ctaColor: .purple)
 /// KovaleeUI.configuration.founderFeedbackText = FeedbackText(introText: "Hi, I'm…", …)
 /// KovaleeUI.configuration.featureFeedbackText = FeatureFeedbackText(choicesTitle: "…", …)
 /// ```
@@ -27,8 +28,9 @@ public enum KovaleeUI {
         public var feedbackChoices: [String] = []
         /// Copy for the founder-feedback sheet. Defaults to ``FeedbackText/preview``.
         public var founderFeedbackText: FeedbackText = .preview
-        /// Styling for both feedback sheets. Defaults to ``FeedbackStyle/default``.
-        public var feedbackStyle: FeedbackStyle = .default
+        /// Styling for the feedback sheets and the subscription-upsell
+        /// post-purchase screens. Defaults to ``KovaleeUIStyle/default``.
+        public var style: KovaleeUIStyle = .default
         /// Copy for the feature-survey sheet. Defaults to ``FeatureFeedbackText/preview``.
         public var featureFeedbackText: FeatureFeedbackText?
     }

--- a/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsell.swift
+++ b/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsell.swift
@@ -22,12 +22,21 @@ import SwiftUI
 /// receives the final outcome.
 public enum SubscriptionUpsell {
 
-	/// Theme used by `presentCongratsScreen` and by the SDK debug-menu preview.
-	/// Hosts can override at launch (e.g. `SubscriptionUpsell.defaultCancelPromptTheme = .pep`)
-	/// so QA sees the production look-and-feel in previews. Per-call Configuration
-	/// theme still takes precedence inside the real upsell flow.
+	/// Style for the post-purchase ("Lifetime unlocked" / cancel-prompt) screens.
+	///
+	/// Resolves to `KovaleeUI.configuration.style` — the single style
+	/// partners already configure for the feedback sheets — so both surfaces
+	/// match out of the box. Falls back to `.default` on iOS < 17, where
+	/// `KovaleeUI.configuration` is unavailable. Per-call
+	/// `Configuration.cancelPromptStyle` still takes precedence inside the real
+	/// upsell flow.
 	@MainActor
-	public static var defaultCancelPromptTheme: Theme = .default
+	static var defaultCancelPromptStyle: KovaleeUIStyle {
+		if #available(iOS 17, *) {
+			return KovaleeUI.configuration.style
+		}
+		return .default
+	}
 
 
 	/// Which source subscription(s) to watch. The SDK resolves the actual
@@ -91,11 +100,11 @@ public enum SubscriptionUpsell {
 		/// the paywall has no dismiss UI of its own.
 		public let showCloseButton: Bool
 
-		/// Visual customization for the post-purchase "Lifetime unlocked"
-		/// screen. When `nil` the orchestrator falls back to
-		/// `SubscriptionUpsell.defaultCancelPromptTheme` (which hosts can
-		/// register once at launch). Pass an explicit `Theme` to override.
-		public let cancelPromptTheme: Theme?
+		/// Per-flow override for the post-purchase screens' styling. When `nil`
+		/// the orchestrator falls back to `KovaleeUI.configuration.style`
+		/// so the upsell matches the feedback sheets. Pass an explicit
+		/// `KovaleeUIStyle` to override just this flow.
+		public let cancelPromptStyle: KovaleeUIStyle?
 
 		public init(
 			offeringId: String,
@@ -105,7 +114,7 @@ public enum SubscriptionUpsell {
 			condition: Condition? = nil,
 			debugForceTrigger: Bool = false,
 			showCloseButton: Bool = false,
-			cancelPromptTheme: Theme? = nil
+			cancelPromptStyle: KovaleeUIStyle? = nil
 		) {
 			self.offeringId = offeringId
 			self.trigger = trigger
@@ -114,7 +123,7 @@ public enum SubscriptionUpsell {
 			self.condition = condition ?? .trialExpiring(within: triggerWithin)
 			self.debugForceTrigger = debugForceTrigger
 			self.showCloseButton = showCloseButton
-			self.cancelPromptTheme = cancelPromptTheme
+			self.cancelPromptStyle = cancelPromptStyle
 		}
 
 		/// Copy with a different RevenueCat offering, keeping every other field.
@@ -128,7 +137,7 @@ public enum SubscriptionUpsell {
 				condition: condition,
 				debugForceTrigger: debugForceTrigger,
 				showCloseButton: showCloseButton,
-				cancelPromptTheme: cancelPromptTheme
+				cancelPromptStyle: cancelPromptStyle
 			)
 		}
 	}
@@ -139,58 +148,6 @@ public enum SubscriptionUpsell {
 		case purchased
 	}
 
-
-	/// Visual customization for the post-purchase "Lifetime unlocked" screen.
-	/// Defaults to system styling so any host gets a sensible look without
-	/// configuration.
-	public struct Theme: Sendable {
-		public var background: Color
-		public var iconTint: Color
-		public var titleColor: Color
-		public var bodyColor: Color
-		public var primaryButtonBackground: Color
-		public var primaryButtonForeground: Color
-		public var secondaryButtonColor: Color
-		public var titleFont: Font
-		public var bodyFont: Font
-		public var buttonFont: Font
-		/// SF Symbol shown above the "Lifetime unlocked" confirmation step.
-		public var iconSystemName: String
-		/// SF Symbol shown above the "One last step" cancel-prompt step. Kept
-		/// separate from `iconSystemName` so the celebratory icon doesn't carry
-		/// over into the more cautionary "turn off auto-renewal" screen.
-		public var cancelPromptIconSystemName: String
-
-		public init(
-			background: Color = Color(.systemBackground),
-			iconTint: Color = .accentColor,
-			titleColor: Color = .primary,
-			bodyColor: Color = .secondary,
-			primaryButtonBackground: Color = .accentColor,
-			primaryButtonForeground: Color = .white,
-			secondaryButtonColor: Color = .secondary,
-			titleFont: Font = .system(size: 32, weight: .semibold),
-			bodyFont: Font = .body,
-			buttonFont: Font = .headline,
-			iconSystemName: String = "checkmark.seal.fill",
-			cancelPromptIconSystemName: String = "exclamationmark.circle.fill"
-		) {
-			self.background = background
-			self.iconTint = iconTint
-			self.titleColor = titleColor
-			self.bodyColor = bodyColor
-			self.primaryButtonBackground = primaryButtonBackground
-			self.primaryButtonForeground = primaryButtonForeground
-			self.secondaryButtonColor = secondaryButtonColor
-			self.titleFont = titleFont
-			self.bodyFont = bodyFont
-			self.buttonFont = buttonFont
-			self.iconSystemName = iconSystemName
-			self.cancelPromptIconSystemName = cancelPromptIconSystemName
-		}
-
-		public static let `default` = Theme()
-	}
 
 	/// UIKit entry point.
 	///
@@ -237,13 +194,13 @@ public enum SubscriptionUpsell {
 
 	/// Presents the "Lifetime unlocked" congrats screen directly. Useful for
 	/// debug menu previews, design reviews, and QA without needing a real
-	/// purchase. Uses `defaultCancelPromptTheme` unless overridden.
+	/// purchase. Uses `KovaleeUI.configuration.style` unless overridden.
 	@MainActor
 	public static func presentCongratsScreen(
-		theme: Theme? = nil,
+		style: KovaleeUIStyle? = nil,
 		onCompletion: (@MainActor @Sendable () -> Void)? = nil
 	) {
-		UpsellPostPurchaseView.launchAtTop(theme: theme ?? defaultCancelPromptTheme) {
+		UpsellPostPurchaseView.launchAtTop(style: style ?? defaultCancelPromptStyle) {
 			onCompletion?()
 		}
 	}

--- a/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsellPresenter.swift
+++ b/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsellPresenter.swift
@@ -82,7 +82,7 @@ enum SubscriptionUpsellPresenter {
 					offering: offering,
 					sourceProduct: sourceProduct,
 					showCloseButton: configuration.showCloseButton,
-					cancelPromptTheme: configuration.cancelPromptTheme ?? SubscriptionUpsell.defaultCancelPromptTheme,
+					cancelPromptStyle: configuration.cancelPromptStyle ?? SubscriptionUpsell.defaultCancelPromptStyle,
 					analyticsContext: context,
 					onCompletion: onCompletion
 				)
@@ -149,7 +149,7 @@ enum SubscriptionUpsellPresenter {
 					offering: offering,
 					sourceProduct: nil,
 					showCloseButton: configuration.showCloseButton,
-					cancelPromptTheme: configuration.cancelPromptTheme ?? SubscriptionUpsell.defaultCancelPromptTheme,
+					cancelPromptStyle: configuration.cancelPromptStyle ?? SubscriptionUpsell.defaultCancelPromptStyle,
 					analyticsContext: context,
 					onCompletion: onCompletion
 				)
@@ -216,7 +216,7 @@ enum SubscriptionUpsellPresenter {
 		offering: Offering,
 		sourceProduct: Product?,
 		showCloseButton: Bool,
-		cancelPromptTheme: SubscriptionUpsell.Theme,
+		cancelPromptStyle: KovaleeUIStyle,
 		analyticsContext: SubscriptionUpsellAnalytics.Context,
 		onCompletion: (@MainActor @Sendable (SubscriptionUpsell.Outcome) -> Void)?
 	) -> UIViewController {
@@ -275,7 +275,7 @@ enum SubscriptionUpsellPresenter {
 			host.dismiss(animated: true) {
 				if purchased {
 					UpsellPostPurchaseView.launchAtTop(
-						theme: cancelPromptTheme,
+						style: cancelPromptStyle,
 						sourceProduct: sourceProduct,
 						analyticsContext: analyticsContext
 					) {

--- a/Sources/KovaleeSDKUI/SubscriptionUpsell/UpsellPostPurchaseView.swift
+++ b/Sources/KovaleeSDKUI/SubscriptionUpsell/UpsellPostPurchaseView.swift
@@ -6,7 +6,7 @@ import UIKit
 
 struct UpsellPostPurchaseView: View {
 	@Environment(\.dismiss) private var dismiss
-	let theme: SubscriptionUpsell.Theme
+	let style: KovaleeUIStyle
 	let sourceProduct: Product?
 	/// Correlation for funnel analytics. `nil` when the screen is shown as a
 	/// standalone preview (debug menu) — no events are fired in that case.
@@ -25,9 +25,16 @@ struct UpsellPostPurchaseView: View {
 		case cancelPrompt
 	}
 
+	/// Matches `ActionButton`'s adaptive contrast: dark text on a light CTA,
+	/// light text on a dark one, so the button label stays legible whatever
+	/// `ctaColor` the host configures.
+	private var primaryButtonForeground: Color {
+		style.ctaColor.isLight ? .black : .white
+	}
+
 	var body: some View {
 		ZStack {
-			theme.background.ignoresSafeArea()
+			style.backgroundColor.ignoresSafeArea()
 
 			switch step {
 			case .confirmation: confirmationStep
@@ -51,19 +58,19 @@ struct UpsellPostPurchaseView: View {
 		VStack(spacing: 24) {
 			Spacer()
 
-			Image(systemName: theme.iconSystemName)
+			Image(systemName: style.confirmationIcon)
 				.font(.system(size: 56))
-				.foregroundStyle(theme.iconTint)
+				.foregroundStyle(style.ctaColor)
 
 			Text("Lifetime unlocked", bundle: .module)
-				.font(theme.titleFont)
-				.foregroundStyle(theme.titleColor)
+				.font(style.titleFont)
+				.foregroundStyle(style.primaryColor)
 				.multilineTextAlignment(.center)
 
 			Text("Your lifetime access is now active.", bundle: .module)
-				.font(theme.bodyFont)
+				.font(style.bodyFont)
 				.multilineTextAlignment(.center)
-				.foregroundStyle(theme.bodyColor)
+				.foregroundStyle(style.secondaryColor)
 				.padding(.horizontal, 24)
 
 			Spacer()
@@ -73,11 +80,11 @@ struct UpsellPostPurchaseView: View {
 				step = .cancelPrompt
 			} label: {
 				Text("OK", bundle: .module)
-					.font(theme.buttonFont)
-					.foregroundStyle(theme.primaryButtonForeground)
+					.font(style.buttonFont)
+					.foregroundStyle(primaryButtonForeground)
 					.frame(maxWidth: .infinity)
 					.frame(height: 56)
-					.background(Capsule().fill(theme.primaryButtonBackground))
+					.background(Capsule().fill(style.ctaColor))
 			}
 			.padding(.horizontal, 24)
 			.padding(.bottom, 24)
@@ -89,19 +96,19 @@ struct UpsellPostPurchaseView: View {
 		VStack(spacing: 24) {
 			Spacer()
 
-			Image(systemName: theme.cancelPromptIconSystemName)
+			Image(systemName: style.cancelPromptIcon)
 				.font(.system(size: 56))
-				.foregroundStyle(theme.iconTint)
+				.foregroundStyle(style.ctaColor)
 
 			Text("One last step", bundle: .module)
-				.font(theme.titleFont)
-				.foregroundStyle(theme.titleColor)
+				.font(style.titleFont)
+				.foregroundStyle(style.primaryColor)
 				.multilineTextAlignment(.center)
 
 			Text("Turn off auto-renewal on your existing subscription so the App Store doesn't charge you again.", bundle: .module)
-				.font(theme.bodyFont)
+				.font(style.bodyFont)
 				.multilineTextAlignment(.center)
-				.foregroundStyle(theme.bodyColor)
+				.foregroundStyle(style.secondaryColor)
 				.padding(.horizontal, 24)
 
 			if let errorMessage {
@@ -119,17 +126,17 @@ struct UpsellPostPurchaseView: View {
 			} label: {
 				ZStack {
 					if isLoading {
-						ProgressView().tint(theme.primaryButtonForeground)
+						ProgressView().tint(primaryButtonForeground)
 					}
 					else {
 						Text("Open subscription settings", bundle: .module)
 					}
 				}
-				.font(theme.buttonFont)
-				.foregroundStyle(theme.primaryButtonForeground)
+				.font(style.buttonFont)
+				.foregroundStyle(primaryButtonForeground)
 				.frame(maxWidth: .infinity)
 				.frame(height: 56)
-				.background(Capsule().fill(theme.primaryButtonBackground))
+				.background(Capsule().fill(style.ctaColor))
 			}
 			.disabled(isLoading)
 			.padding(.horizontal, 24)
@@ -142,7 +149,7 @@ struct UpsellPostPurchaseView: View {
 			} label: {
 				Text("I'll do it later", bundle: .module)
 					.font(.subheadline)
-					.foregroundStyle(theme.secondaryButtonColor)
+					.foregroundStyle(style.secondaryColor)
 			}
 			.padding(.bottom, 24)
 		}
@@ -249,7 +256,7 @@ extension UpsellPostPurchaseView {
 
 	@MainActor
 	static func launchAtTop(
-		theme: SubscriptionUpsell.Theme,
+		style: KovaleeUIStyle,
 		sourceProduct: Product? = nil,
 		analyticsContext: SubscriptionUpsellAnalytics.Context? = nil,
 		onDismiss: @escaping @MainActor () -> Void
@@ -260,7 +267,7 @@ extension UpsellPostPurchaseView {
 		}
 		let host = UIHostingController(
 			rootView: UpsellPostPurchaseView(
-				theme: theme,
+				style: style,
 				sourceProduct: sourceProduct,
 				analyticsContext: analyticsContext,
 				onDismiss: onDismiss


### PR DESCRIPTION
## Summary

Unifies the **feedback sheets** and the **subscription-upsell post-purchase screens** onto a single styling type. Previously each surface had its own type (`FeedbackStyle` vs. `SubscriptionUpsell.Theme`) with different field names, so a partner had to configure colors twice and the two could drift.

Now there is **one** type — `KovaleeUIStyle` (renamed from `FeedbackStyle`) — configured **once** via `KovaleeUI.configuration.style`, and both surfaces honor it. The post-upsell screen matches the feedback theme out of the box.

## What changed

- `FeedbackStyle` → **`KovaleeUIStyle`**, now the single style type for both features.
- It gains **upsell-only** fields (`titleFont`, `bodyFont`, `buttonFont`, `confirmationIcon`, `cancelPromptIcon`) on top of the shared colors.
- The upsell post-purchase view consumes `KovaleeUIStyle` directly; its CTA text color is derived adaptively for contrast against `ctaColor` (same logic as the feedback `ActionButton`).
- Default style source: `KovaleeUI.configuration.style`; per-flow override via `SubscriptionUpsell.Configuration.cancelPromptStyle`.
- `KovaleeUIStyle` availability lowered to the **package floor (iOS 15)** — it is a pure value type, and this keeps the upsell (incl. the "turn off auto-renewal" prompt) working below iOS 17.

## API changes (⚠️ breaking — with deprecation shims)

Migration shims live in `Sources/KovaleeSDKUI/Deprecations.swift` (`@available(*, deprecated, renamed:)`), to be removed next major.

| Old | New |
|---|---|
| `FeedbackStyle` | `KovaleeUIStyle` |
| `KovaleeUI.configuration.feedbackStyle` | `KovaleeUI.configuration.style` |
| `SubscriptionUpsell.Theme` | `KovaleeUIStyle` |
| `SubscriptionUpsell.defaultCancelPromptTheme` | `KovaleeUI.configuration.style` |
| `Configuration.cancelPromptTheme` | `Configuration.cancelPromptStyle` |
| `presentCongratsScreen(theme:)` | `presentCongratsScreen(style:)` |

`FeedbackStyle` callers are source-compatible (the alias keeps the same init shape). `SubscriptionUpsell.Theme` constructions using the old field labels (`titleColor`, `iconTint`, …) need a manual field-name migration since the type was restructured, not purely renamed.

## Behavior notes

- The upsell loses a few independent knobs that are now derived: the icon tint and primary-button background both map to `ctaColor`, and the button foreground is computed for contrast (was a settable `primaryButtonForeground`, default `.white`).
- Fonts/icons on `KovaleeUIStyle` are consumed only by the upsell; the feedback sheets keep their fixed typography.

## Open for review

- **`defaultCancelPromptTheme` shim semantics**: its setter now writes the *shared* style (so it also restyles feedback) and is a no-op on iOS < 17. Consider marking it `@available(*, unavailable, message:)` instead of `deprecated`, since the meaning changed rather than just the name.
- Optional: move `KovaleeUIStyle` out of `UserFeedbackConfiguration.swift` into its own file now that it's cross-feature.
