### PR TITLE
:sparkles: Support analytics-only watchOS targets with no-op managers

### DIFF
--- a/Sources/KovaleeSDK/Common/NoopManagers.swift
+++ b/Sources/KovaleeSDK/Common/NoopManagers.swift
@@ -1,0 +1,101 @@
+#if os(watchOS)
+import Foundation
+import KovaleeFramework
+
+/// watchOS builds link only ``KovaleeSDK`` (analytics). The attribution
+/// (Adjust), purchases (RevenueCat) and remote-config (Firebase) modules are
+/// not part of an analytics-only watch target — Adjust doesn't even ship a
+/// watchOS slice — yet ``KovaleeManager`` requires all three managers to be
+/// non-nil. These no-op implementations satisfy that contract so
+/// ``Kovalee/initialize(configuration:)`` succeeds with just the event tracker.
+///
+/// Any call that would need a real backing service throws
+/// ``NoopManagerError/unavailableOnWatchOS`` rather than returning fake data.
+
+enum NoopManagerError: Error {
+    /// The capability is not available in an analytics-only watchOS build.
+    case unavailableOnWatchOS
+}
+
+struct NoopAttributionManager: AttributionManager {
+    func getAttributionAdid() async -> String? { nil }
+
+    func sendConversionValue(value _: Int, coarseValue _: String?, completion: @escaping ((any Error)?) -> Void) {
+        completion(nil)
+    }
+
+    func setDataCollectionEnabled(_: Bool) {}
+
+    func setAttributionDelegate(_: any KovaleeAttributionDelegate) {}
+}
+
+struct NoopRemoteConfigurationManager: RemoteConfigurationManager {
+    func setFetchTimeout(_: Double) {}
+
+    func fetchAndActivateRemoteConfig() async {}
+
+    func setDefaultValues(_: [String: Any]) {}
+
+    func value(forKey _: String) async throws -> Data {
+        throw NoopManagerError.unavailableOnWatchOS
+    }
+
+    func setDataCollectionEnabled(_: Bool) {}
+
+    func setAdvertisingConsentGranted(_: Bool) {}
+}
+
+struct NoopPurchaseManager: PurchaseManager {
+    func revenueCatUserId() -> String { "" }
+
+    func setUserId(userId _: String) async throws -> (any AbstractCustomerInfo, created: Bool) {
+        throw NoopManagerError.unavailableOnWatchOS
+    }
+
+    func setEmail(email _: String) {}
+
+    func logout() async throws -> any AbstractCustomerInfo {
+        throw NoopManagerError.unavailableOnWatchOS
+    }
+
+    func setAttribution(adid _: String) {}
+
+    func setAmplitudeUserId(userId _: String) {}
+
+    func syncPurchase() async throws -> any AbstractCustomerInfo {
+        throw NoopManagerError.unavailableOnWatchOS
+    }
+
+    func customerInfo() async throws -> any AbstractCustomerInfo {
+        throw NoopManagerError.unavailableOnWatchOS
+    }
+
+    func fetchOfferings() async throws -> (any AbstractOfferings)? { nil }
+
+    func fetchCurrentOffering() async throws -> (any AbstractOffering)? { nil }
+
+    func restorePurchases() async throws -> any AbstractCustomerInfo {
+        throw NoopManagerError.unavailableOnWatchOS
+    }
+
+    func purchase(package _: any AbstractPackage) async throws -> any AbstractPurchaseResultData {
+        throw NoopManagerError.unavailableOnWatchOS
+    }
+
+    func purchaseProduct(withId _: String) async throws -> any AbstractPurchaseResultData {
+        throw NoopManagerError.unavailableOnWatchOS
+    }
+
+    func checkTrialOrIntroDiscountEligibility(productIdentifiers _: [String]) async -> [String: Int] { [:] }
+
+    func setPurchaseDelegate(_: any KovaleePurchasesDelegate) {}
+
+    func cancellableStripeSubscriptionId() async throws -> String? { nil }
+
+    func handleWebRedemptionURL(_: URL) async throws -> Bool { false }
+
+    func handleWebUser(withId _: String) async throws -> Bool { false }
+
+    func isRCWebPurchaseRedemptionURL(_: URL) -> Bool { false }
+}
+#endif

--- a/Sources/KovaleeSDK/Kovalee.swift
+++ b/Sources/KovaleeSDK/Kovalee.swift
@@ -66,17 +66,30 @@ public final class Kovalee {
                 fatalError("Failed to create EventTrackerManager")
             }
 
+            // Analytics-only watchOS targets link just KovaleeSDK — the
+            // attribution (Adjust, no watchOS slice), purchases (RevenueCat) and
+            // remote-config (Firebase) modules aren't present, so their managers
+            // can't be created. Fall back to no-op implementations there instead
+            // of crashing. Every other platform keeps the strict contract: a
+            // missing manager means the module wasn't linked, which is a
+            // misconfiguration we want to surface immediately.
+            #if os(watchOS)
+            let attributionManager = (Kovalee.setupCapabilities(forItem: .attribution, withConfiguration: configuration, andKeys: keys) as? AttributionManager) ?? NoopAttributionManager()
+            let purchaseManager = (Kovalee.setupCapabilities(forItem: .purchases, withConfiguration: configuration, andKeys: keys) as? PurchaseManager) ?? NoopPurchaseManager()
+            let remoteConfigManager = (Kovalee.setupCapabilities(forItem: .remoteConfiguration, withConfiguration: configuration, andKeys: keys) as? RemoteConfigurationManager) ?? NoopRemoteConfigurationManager()
+            #else
             guard let attributionManager = Kovalee.setupCapabilities(forItem: .attribution, withConfiguration: configuration, andKeys: keys) as? AttributionManager else {
-                fatalError("Failed to create EventTrackerManager")
+                fatalError("Failed to create AttributionManager")
             }
 
             guard let purchaseManager = Kovalee.setupCapabilities(forItem: .purchases, withConfiguration: configuration, andKeys: keys) as? PurchaseManager else {
-                fatalError("Failed to create EventTrackerManager")
+                fatalError("Failed to create PurchaseManager")
             }
 
             guard let remoteConfigManager = Kovalee.setupCapabilities(forItem: .remoteConfiguration, withConfiguration: configuration, andKeys: keys) as? RemoteConfigurationManager else {
-                fatalError("Failed to create EventTrackerManager")
+                fatalError("Failed to create RemoteConfigurationManager")
             }
+            #endif
 
             let surveyManager = Kovalee.setupCapabilities(forItem: .survey, withConfiguration: configuration, andKeys: keys) as? SurveyManager
 


### PR DESCRIPTION
## Context

A watchOS app that links only `KovaleeSDK` (analytics) crashes in `Kovalee.initialize` with `Fatal error: Failed to create EventTrackerManager`, because the init path requires the attribution, purchases and remote-config managers to be non-nil. Those modules aren't part of an analytics-only watch target — Adjust doesn't even ship a watchOS slice. Reported by Dmitry on Slack while integrating the SDK in a watch app.

## Changes

- **`NoopManagers.swift`** (new, `#if os(watchOS)` only): `NoopAttributionManager`, `NoopPurchaseManager` and `NoopRemoteConfigurationManager`. Calls that would need a real backing service throw `NoopManagerError.unavailableOnWatchOS` instead of returning fake data; the rest are silent no-ops.
- **`Kovalee.swift`**: on watchOS, fall back to the no-op managers when a module isn't linked instead of hitting `fatalError`. All other platforms keep the strict contract (missing module = misconfiguration = crash at init). If a module *is* linked on watchOS (e.g. RevenueCat, which does support it), the real manager is still used.
- Fixed the three copy-pasted guard messages that all said `Failed to create EventTrackerManager`.

