### PR TITLE
:sparkles: Expose trial period and lifetime products on KCustomerInfo [STU-3327]

### DIFF
--- a/Sources/KovaleePurchases/StoreDataModel.swift
+++ b/Sources/KovaleePurchases/StoreDataModel.swift
@@ -53,6 +53,14 @@ public final class KCustomerInfo: AbstractCustomerInfo, Encodable {
         !entitlements.active.isEmpty
     }
 
+    public var isInTrialPeriod: Bool {
+        entitlements.active.contains { $0.value.periodType == .trial }
+    }
+
+    public var nonSubscriptionProductIds: [String] {
+        nonSubscriptions.map(\.productIdentifier)
+    }
+
     init(info: RevenueCat.CustomerInfo) {
         entitlements = KEntitlementInfos(entitlements: info.entitlements)
         activeSubscriptions = info.activeSubscriptions

--- a/Sources/KovaleeSDK/KovaleeCRM.swift
+++ b/Sources/KovaleeSDK/KovaleeCRM.swift
@@ -11,7 +11,9 @@ public extension Kovalee {
 
     /// Creates a contact in Brevo CRM with the provided email and optional attributes.
     ///
-    /// The SDK automatically attaches the app code, Amplitude user ID, and device ID.
+    /// The SDK automatically attaches the app code, Amplitude user ID, device ID,
+    /// and RevenueCat app user ID (so the server can reconcile purchases made
+    /// before the email was known).
     ///
     /// - Parameters:
     ///   - email: the email address for the Brevo contact


### PR DESCRIPTION
## Why

Companion to cotyapps/Kovalee-iOS-Framework#153: `createBrevoContact` now sends the user's purchase snapshot so studio-server can set the Brevo subscription status when the email is entered after the paywall (where the purchase webhook arrives without `$email` and is dropped).

The framework's `AbstractCustomerInfo` protocol gained `isInTrialPeriod` and `nonSubscriptionProductIds` (with defaults) — this PR provides the real implementations on `KCustomerInfo`, which already maps everything needed from RevenueCat:

- `isInTrialPeriod` — any active entitlement with `periodType == .trial`
- `nonSubscriptionProductIds` — product ids from `nonSubscriptions` (one-time/lifetime purchases, which `activeSubscriptions` misses)

Also documents the new automatic fields on `Kovalee.createBrevoContact`.

The overrides become active once this module is compiled against the framework binary containing #153; against an older binary they are inert extra members — no lockstep required.

Based on `facebook-conversion-tracking` per release planning.