### PR TITLE
:sparkles: Add "Present Paywall" debug section for subscription upsell

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ The SDK's `DebugView` exposes a *Subscription Upsell* section (visible when **En
 - **Force Trigger on Launch** — behaves as if a matching trial entitlement existed, regardless of subscription state. Gated to debug/TestFlight builds.
 - **Reset Shown State** — clears the show-once flag so the flow can fire again.
 - **Preview Congrats Screen** — opens the post-purchase screen directly to validate theming.
+- **Present Paywall** — lists every RevenueCat offering (the active one marked *(current)*) and force-presents its upsell paywall immediately, bypassing eligibility and the show-once gate. Always shows a close button so the paywall is dismissable regardless of the offering's template.
 
 ### Outcomes
 

--- a/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsell+SwiftUI.swift
+++ b/Sources/KovaleeSDKUI/SubscriptionUpsell/SubscriptionUpsell+SwiftUI.swift
@@ -1,7 +1,6 @@
 import Foundation
 #if os(iOS)
 import SwiftUI
-import UIKit
 
 public extension View {
 
@@ -39,26 +38,12 @@ private struct SubscriptionUpsellModifier: ViewModifier {
 		SubscriptionUpsellPresenter.run(
 			configuration: configuration,
 			present: { viewController in
-				guard let presenter = SubscriptionUpsellModifier.topPresenter else { return false }
+				guard let presenter = TopPresenter.current else { return false }
 				presenter.present(viewController, animated: true)
 				return true
 			},
 			onCompletion: onCompletion
 		)
-	}
-
-
-	@MainActor
-	private static var topPresenter: UIViewController? {
-		let scene = UIApplication.shared.connectedScenes
-			.compactMap { $0 as? UIWindowScene }
-			.first { $0.activationState == .foregroundActive }
-		guard let root = scene?.keyWindow?.rootViewController else { return nil }
-		var top = root
-		while let presented = top.presentedViewController {
-			top = presented
-		}
-		return top
 	}
 }
 #endif

--- a/Sources/KovaleeSDKUI/SubscriptionUpsell/TopPresenter.swift
+++ b/Sources/KovaleeSDKUI/SubscriptionUpsell/TopPresenter.swift
@@ -1,0 +1,25 @@
+import Foundation
+#if os(iOS)
+import UIKit
+
+/// Resolves the top-most view controller to present from, so the upsell flow
+/// (SwiftUI modifier, post-purchase screens, debug menu) doesn't need a
+/// `UIViewController` handle threaded through.
+enum TopPresenter {
+
+	/// The frontmost presented controller of the active foreground scene, falling
+	/// back to any connected window scene when none is `.foregroundActive`.
+	@MainActor
+	static var current: UIViewController? {
+		let scenes = UIApplication.shared.connectedScenes
+			.compactMap { $0 as? UIWindowScene }
+		let scene = scenes.first { $0.activationState == .foregroundActive } ?? scenes.first
+		guard let root = scene?.keyWindow?.rootViewController else { return nil }
+		var top = root
+		while let presented = top.presentedViewController {
+			top = presented
+		}
+		return top
+	}
+}
+#endif

--- a/Sources/KovaleeSDKUI/SubscriptionUpsell/UpsellPostPurchaseView.swift
+++ b/Sources/KovaleeSDKUI/SubscriptionUpsell/UpsellPostPurchaseView.swift
@@ -261,7 +261,7 @@ extension UpsellPostPurchaseView {
 		analyticsContext: SubscriptionUpsellAnalytics.Context? = nil,
 		onDismiss: @escaping @MainActor () -> Void
 	) {
-		guard let topPresenter = Self.topPresenter else {
+		guard let topPresenter = TopPresenter.current else {
 			onDismiss()
 			return
 		}
@@ -275,23 +275,6 @@ extension UpsellPostPurchaseView {
 		)
 		host.modalPresentationStyle = .fullScreen
 		topPresenter.present(host, animated: true)
-	}
-
-
-	@MainActor
-	private static var topPresenter: UIViewController? {
-		let scene = UIApplication.shared.connectedScenes
-			.compactMap { $0 as? UIWindowScene }
-			.first { $0.activationState == .foregroundActive }
-			?? UIApplication.shared.connectedScenes
-				.compactMap { $0 as? UIWindowScene }
-				.first
-		guard let root = scene?.keyWindow?.rootViewController else { return nil }
-		var top = root
-		while let presented = top.presentedViewController {
-			top = presented
-		}
-		return top
 	}
 }
 #endif

--- a/Sources/KovaleeSDKUI/Subviews/SubscriptionUpsellDebugView.swift
+++ b/Sources/KovaleeSDKUI/Subviews/SubscriptionUpsellDebugView.swift
@@ -1,11 +1,23 @@
 #if os(iOS)
 import SwiftUI
+import RevenueCat
 
 @available(iOS 16.0, *)
 struct SubscriptionUpsellDebugView: View {
 
 	@AppStorage(SubscriptionUpsellOverride.forceTriggerKey) private var forceTrigger: Bool = false
 	@State private var showResetAlert: Bool = false
+
+	@State private var offeringIds: [String] = []
+	@State private var currentOfferingId: String?
+	@State private var offeringsState: OfferingsState = .idle
+
+	private enum OfferingsState: Equatable {
+		case idle
+		case loading
+		case loaded
+		case failed(String)
+	}
 
 	var body: some View {
 		Toggle("Force Trigger on Launch", isOn: $forceTrigger)
@@ -38,6 +50,117 @@ struct SubscriptionUpsellDebugView: View {
 		} message: {
 			Text("Cleared show-once flags. The next eligible foreground will trigger the flow.")
 		}
+
+		presentPaywallSection
+			.task { await loadOfferings() }
+	}
+
+
+	/// Presents the real upsell paywall on demand, bypassing eligibility and the
+	/// show-once gate. Lists every RevenueCat offering so QA can test any paywall
+	/// without knowing the host app's configured offering id.
+	@ViewBuilder
+	private var presentPaywallSection: some View {
+		VStack(alignment: .leading, spacing: 10) {
+			Text("Present Paywall")
+				.font(.footnote.weight(.semibold))
+				.foregroundStyle(.secondary)
+				.frame(maxWidth: .infinity, alignment: .leading)
+
+			switch offeringsState {
+			case .idle, .loading:
+				HStack(spacing: 8) {
+					ProgressView()
+					Text("Loading offerings…")
+						.font(.caption)
+						.foregroundStyle(.secondary)
+				}
+				.frame(maxWidth: .infinity, alignment: .leading)
+
+			case .failed(let message):
+				VStack(alignment: .leading, spacing: 8) {
+					Text("Couldn't load offerings: \(message)")
+						.font(.caption)
+						.foregroundStyle(.red)
+						.frame(maxWidth: .infinity, alignment: .leading)
+
+					Button {
+						Task { await reloadOfferings() }
+					} label: {
+						Label("Retry", systemImage: "arrow.clockwise")
+					}
+					.buttonStyle(.debugSecondary)
+				}
+
+			case .loaded where offeringIds.isEmpty:
+				Text("No offerings found in RevenueCat.")
+					.font(.caption)
+					.foregroundStyle(.secondary)
+					.frame(maxWidth: .infinity, alignment: .leading)
+
+			case .loaded:
+				ForEach(offeringIds, id: \.self) { id in
+					Button {
+						SubscriptionUpsellDebug.presentPaywall(offeringId: id)
+					} label: {
+						Label(label(for: id), systemImage: "creditcard")
+					}
+					.buttonStyle(.debugSecondary)
+				}
+			}
+		}
+	}
+
+
+	private func label(for id: String) -> String {
+		id == currentOfferingId ? "\(id) (current)" : id
+	}
+
+
+	@MainActor
+	private func reloadOfferings() async {
+		offeringsState = .idle
+		await loadOfferings()
+	}
+
+
+	@MainActor
+	private func loadOfferings() async {
+		guard offeringsState == .idle else { return }
+		guard Purchases.isConfigured else {
+			offeringsState = .failed("Purchases not configured")
+			return
+		}
+		offeringsState = .loading
+		do {
+			let offerings = try await Purchases.shared.offerings()
+			currentOfferingId = offerings.current?.identifier
+			offeringIds = offerings.all.keys.sorted()
+			offeringsState = .loaded
+		}
+		catch {
+			offeringsState = .failed(error.localizedDescription)
+		}
+	}
+}
+
+
+/// Debug-only bridge that force-presents the upsell paywall from the top-most
+/// view controller, so the debug menu doesn't need a `UIViewController` handle.
+private enum SubscriptionUpsellDebug {
+
+	@MainActor
+	static func presentPaywall(offeringId: String) {
+		guard let presenter = TopPresenter.current else { return }
+		SubscriptionUpsell.presentNow(
+			configuration: SubscriptionUpsell.Configuration(
+				offeringId: offeringId,
+				trigger: .anySubscription,
+				storageKey: "debug.\(offeringId)",
+				showCloseButton: true
+			),
+			from: presenter
+		)
 	}
 }
 #endif


### PR DESCRIPTION
## What

Adds a **Present Paywall** section to the SDK's `DebugView` (Subscription Upsell). It lets QA force-present any RevenueCat offering's upsell paywall on demand, **bypassing eligibility and the show-once gate** — no need to know the host app's configured offering id.

- Lists every RevenueCat offering, with the active one marked *(current)*.
- Tapping an offering force-presents its paywall via `SubscriptionUpsell.presentNow`, always with a close button so it's dismissable regardless of the RC template.
- Loads offerings on appear with `idle → loading → loaded/failed` states, and a **Retry** button on failure.

## Refactor

Deduplicates the three near-identical copies of the top-most-view-controller resolver (SwiftUI modifier, post-purchase screens, new debug bridge) into a single internal `TopPresenter.current` helper. Behavior-preserving on all three paths.

## Testing

- `xcodebuild -scheme KovaleeSDKUI -destination 'generic/platform=iOS'` — **BUILD SUCCEEDED**, no warnings.
- All new code is `#if os(iOS)`-guarded.